### PR TITLE
Fix machine cover safe mode in TecTech

### DIFF
--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/base/GT_MetaTileEntity_MultiblockBase_EM.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/base/GT_MetaTileEntity_MultiblockBase_EM.java
@@ -1677,7 +1677,7 @@ public abstract class GT_MetaTileEntity_MultiblockBase_EM extends GT_MetaTileEnt
             addEnergyOutput_EM((long) mEUt * (long) mEfficiency / getMaxEfficiency(aStack), eAmpereFlow);
         } else if (euFlow < 0) {
             if (!drainEnergyInput_EM(mEUt, (long) mEUt * getMaxEfficiency(aStack) / Math.max(1000L, mEfficiency), eAmpereFlow)) {
-                stopMachine();
+                criticalStopMachine();
                 return false;
             }
         }
@@ -1690,7 +1690,7 @@ public abstract class GT_MetaTileEntity_MultiblockBase_EM extends GT_MetaTileEnt
             addEnergyOutput_EM((long) mEUt * (long) mEfficiency / getMaxEfficiency(aStack), eAmpereFlow);
         } else if (euFlow < 0) {
             if (!drainEnergyInput((long) mEUt * getMaxEfficiency(aStack) / Math.max(1000L, mEfficiency), eAmpereFlow)) {
-                stopMachine();
+                criticalStopMachine();
                 return false;
             }
         }


### PR DESCRIPTION
Thanks to **sxtyzhangzk** for the code pointer! I just changed exactly what was described in this comment:
 * https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8104#issuecomment-889000350

I tested with the microwave grinder (since EBF and vacuum freezer are no longer in TecTech). When out of power, the machine controller cover switches its settings to "Disable machine".
 * Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8104