### PR TITLE
Fix cycle in class initialization order

### DIFF
--- a/src/main/java/com/github/technus/tectech/mechanics/alignment/enumerable/ExtendedFacing.java
+++ b/src/main/java/com/github/technus/tectech/mechanics/alignment/enumerable/ExtendedFacing.java
@@ -138,9 +138,9 @@ public enum ExtendedFacing {
 
     ExtendedFacing(String name) {
         this.name = name;
-        direction= Direction.VALUES[ordinal()/(ROTATIONS_COUNT*FLIPS_COUNT)].getForgeDirection();
-        rotation=Rotation.VALUES[ordinal()/FLIPS_COUNT-direction.ordinal()*ROTATIONS_COUNT];
-        flip=Flip.VALUES[ordinal()%FLIPS_COUNT];
+        direction= Direction.VALUES[ordinal()/(Rotation.COUNT*Flip.COUNT)].getForgeDirection();
+        rotation=Rotation.VALUES[ordinal()/Flip.COUNT-direction.ordinal()*Rotation.COUNT];
+        flip=Flip.VALUES[ordinal()%Flip.COUNT];
         ForgeDirection a,b,c;
         switch (direction){
             case DOWN:

--- a/src/main/java/com/github/technus/tectech/mechanics/alignment/enumerable/Flip.java
+++ b/src/main/java/com/github/technus/tectech/mechanics/alignment/enumerable/Flip.java
@@ -20,6 +20,7 @@ public enum Flip {
     private final String name;
 
     public static final Flip[] VALUES = values();
+    public static final int COUNT = VALUES.length;
     private static final Map<String, Flip> NAME_LOOKUP = stream(VALUES).collect(toMap(Flip::getName2, (flip) -> flip));
 
     Flip(int oppositeIn, String nameIn) {

--- a/src/main/java/com/github/technus/tectech/mechanics/alignment/enumerable/Rotation.java
+++ b/src/main/java/com/github/technus/tectech/mechanics/alignment/enumerable/Rotation.java
@@ -20,6 +20,7 @@ public enum Rotation {
     private final String name;
 
     public static final Rotation[] VALUES = values();
+    public static final int COUNT = VALUES.length;
     private static final Map<String, Rotation> NAME_LOOKUP = stream(VALUES).collect(toMap(Rotation::getName2, (rotation) -> rotation));
 
     Rotation(int oppositeIn, String nameIn) {


### PR DESCRIPTION

ExtendedFacing depends on IAlignment being fully initialized to be instantiated as part of its class initializer, which in turn require ExtendedFacing to be fully initialized to complete class initialization. How does this even work before?

Fix GTNewHorizons/GT-New-Horizons-Modpack#8704