### PR TITLE
Remove the place holder recipe of xSMD

### DIFF
--- a/src/main/java/com/github/technus/tectech/compatibility/dreamcraft/DreamCraftRecipeLoader.java
+++ b/src/main/java/com/github/technus/tectech/compatibility/dreamcraft/DreamCraftRecipeLoader.java
@@ -1188,35 +1188,15 @@ public class DreamCraftRecipeLoader {
                         Materials.Radon.getGas(2500L),
                 }, ItemList.Circuit_Wetwaremainframe.get(1L), 2000, 300000);
 
-        //UHV Circuit xSMD
-        TT_recipeAdder.addResearchableAssemblylineRecipe(ItemList.Circuit_Parts_TransistorXSMD.get(1L),
-                24000, 64, 50000, 4, new Object[]{
-                        GT_OreDictUnificator.get(OrePrefixes.frameGt, Materials.Tritanium, 2),
-                        ItemList.Circuit_Wetwaresupercomputer.get(2L),
-                        ItemList.ZPM_Coil.get(16L),
-                        ItemList.Circuit_Parts_CapacitorXSMD.get(4L),
-                        ItemList.Circuit_Parts_ResistorXSMD.get(4L),
-                        ItemList.Circuit_Parts_TransistorXSMD.get(4L),
-                        ItemList.Circuit_Parts_DiodeXSMD.get(4L),
-                        ItemList.Circuit_Chip_Ram.get(48L),
-                        GT_OreDictUnificator.get(OrePrefixes.wireGt01, Materials.SuperconductorZPM, 64L),
-                        new Object[]{OrePrefixes.foil.get(Materials.AnySyntheticRubber), 64L},
-                }, new FluidStack[]{
-                        Materials.SolderingAlloy.getMolten(2880L),
-                        new FluidStack(FluidRegistry.getFluid("ic2coolant"), 10000),
-                        Materials.Radon.getGas(2500L),
-                }, ItemList.Circuit_Wetwaremainframe.get(1L), 2000, 300000);
-
-
-        //Bio Chips ASMD
+        //Bio Chips
         TT_recipeAdder.addResearchableAssemblylineRecipe(ItemList.Circuit_Biowarecomputer.get(1L),
                 48000, 128, 500000, 8, new Object[]{
                         ItemList.Circuit_Board_Bio_Ultra.get(2L),
                         ItemList.Circuit_Biowarecomputer.get(2L),
-                        ItemList.Circuit_Parts_TransistorASMD.get(16L),
-                        ItemList.Circuit_Parts_ResistorASMD.get(16L),
-                        ItemList.Circuit_Parts_CapacitorASMD.get(16L),
-                        ItemList.Circuit_Parts_DiodeASMD.get(16L),
+                        new ItemStack[]{ItemList.Circuit_Parts_TransistorASMD.get(16L), ItemList.Circuit_Parts_TransistorXSMD.get(4L)},
+                        new ItemStack[]{ItemList.Circuit_Parts_ResistorASMD.get(16L), ItemList.Circuit_Parts_ResistorXSMD.get(4L)},
+                        new ItemStack[]{ItemList.Circuit_Parts_CapacitorASMD.get(16L), ItemList.Circuit_Parts_CapacitorXSMD.get(4L)},
+                        new ItemStack[]{ItemList.Circuit_Parts_DiodeASMD.get(16L), ItemList.Circuit_Parts_DiodeXSMD.get(4L)},
                         ItemList.Circuit_Chip_NOR.get(32L),
                         ItemList.Circuit_Chip_Ram.get(64L),
                         GT_OreDictUnificator.get(OrePrefixes.wireFine, Materials.NiobiumTitanium, 32L),
@@ -1228,58 +1208,16 @@ public class DreamCraftRecipeLoader {
                 },
                 ItemList.Circuit_Biowaresupercomputer.get(1L), 4000, 500000);
 
-
-        //Bio Chips xSMD
-        TT_recipeAdder.addResearchableAssemblylineRecipe(ItemList.Circuit_Parts_ResistorXSMD.get(1L),
-                48000, 128, 500000, 8, new Object[]{
-                        ItemList.Circuit_Board_Bio_Ultra.get(2L),
-                        ItemList.Circuit_Biowarecomputer.get(2L),
-                        ItemList.Circuit_Parts_TransistorXSMD.get(4L),
-                        ItemList.Circuit_Parts_ResistorXSMD.get(4L),
-                        ItemList.Circuit_Parts_CapacitorXSMD.get(4L),
-                        ItemList.Circuit_Parts_DiodeXSMD.get(4L),
-                        ItemList.Circuit_Chip_NOR.get(32L),
-                        ItemList.Circuit_Chip_Ram.get(64L),
-                        GT_OreDictUnificator.get(OrePrefixes.wireFine, Materials.NiobiumTitanium, 32L),
-                        new Object[]{OrePrefixes.foil.get(Materials.AnySyntheticRubber), 64L},
-                }, new FluidStack[]{
-                        Materials.SolderingAlloy.getMolten(1440L),
-                        Materials.BioMediumSterilized.getFluid(1440L),
-                        new FluidStack(FluidRegistry.getFluid("ic2coolant"), 10000)
-                },
-                ItemList.Circuit_Biowaresupercomputer.get(1L), 4000, 500000);
-
-        // Bio ASMD
+        // Bio
         TT_recipeAdder.addResearchableAssemblylineRecipe(ItemList.Circuit_Biowaresupercomputer.get(1L),
                 96000, 256, 1000000, 16, new Object[]{
                         GT_OreDictUnificator.get(OrePrefixes.frameGt, Materials.Tritanium, 4L),
                         ItemList.Circuit_Biowaresupercomputer.get(2L),
                         ItemList.UV_Coil.get(16L),
-                        ItemList.Circuit_Parts_CapacitorASMD.get(24L),
-                        ItemList.Circuit_Parts_ResistorASMD.get(24L),
-                        ItemList.Circuit_Parts_TransistorASMD.get(24L),
-                        ItemList.Circuit_Parts_DiodeASMD.get(24L),
-                        ItemList.Circuit_Chip_Ram.get(64L),
-                        GT_OreDictUnificator.get(OrePrefixes.wireGt01, Materials.SuperconductorUHV, 64),
-                        new Object[]{OrePrefixes.foil.get(Materials.AnySyntheticRubber), 64L},
-                        GT_OreDictUnificator.get(OrePrefixes.foil, Materials.Polybenzimidazole, 64)
-                }, new FluidStack[]{
-                        Materials.SolderingAlloy.getMolten(2880L),
-                        Materials.BioMediumSterilized.getFluid(2880L),
-                        new FluidStack(FluidRegistry.getFluid("ic2coolant"), 20000)
-                }, ItemList.Circuit_Biomainframe.get(1L), 6000, 2000000);
-
-
-        // Bio xSMD
-        TT_recipeAdder.addResearchableAssemblylineRecipe(ItemList.Circuit_Parts_CapacitorXSMD.get(1L),
-                96000, 256, 1000000, 16, new Object[]{
-                        GT_OreDictUnificator.get(OrePrefixes.frameGt, Materials.Tritanium, 4L),
-                        ItemList.Circuit_Biowaresupercomputer.get(2L),
-                        ItemList.UV_Coil.get(16L),
-                        ItemList.Circuit_Parts_CapacitorXSMD.get(6L),
-                        ItemList.Circuit_Parts_ResistorXSMD.get(6L),
-                        ItemList.Circuit_Parts_TransistorXSMD.get(6L),
-                        ItemList.Circuit_Parts_DiodeXSMD.get(6L),
+                        new ItemStack[]{ItemList.Circuit_Parts_TransistorASMD.get(24L), ItemList.Circuit_Parts_TransistorXSMD.get(6L)},
+                        new ItemStack[]{ItemList.Circuit_Parts_ResistorASMD.get(24L), ItemList.Circuit_Parts_ResistorXSMD.get(6L)},
+                        new ItemStack[]{ItemList.Circuit_Parts_CapacitorASMD.get(24L), ItemList.Circuit_Parts_CapacitorXSMD.get(6L)},
+                        new ItemStack[]{ItemList.Circuit_Parts_DiodeASMD.get(24L), ItemList.Circuit_Parts_DiodeXSMD.get(6L)},
                         ItemList.Circuit_Chip_Ram.get(64L),
                         GT_OreDictUnificator.get(OrePrefixes.wireGt01, Materials.SuperconductorUHV, 64),
                         new Object[]{OrePrefixes.foil.get(Materials.AnySyntheticRubber), 64L},

--- a/src/main/java/com/github/technus/tectech/recipe/TT_recipeAdder.java
+++ b/src/main/java/com/github/technus/tectech/recipe/TT_recipeAdder.java
@@ -77,7 +77,7 @@ public class  TT_recipeAdder extends GT_RecipeAdder {
                 ItemStack[] aStacks = (ItemStack[]) obj;
                 if (aStacks.length > 0) {
                     tInputs[i] = aStacks[0];
-                    tAlts[i] = (ItemStack[]) Arrays.copyOf(aStacks, aStacks.length);
+                    tAlts[i] = Arrays.copyOf(aStacks, aStacks.length);
                     for (ItemStack tAlt : tAlts[i]) {
                         tPersistentHash = tPersistentHash * 31 + GT_Utility.persistentHash(tAlt, true, false);
                     }


### PR DESCRIPTION
just find out that assline can support different input recipes. so don't need to register a place holder recipe for xsmd and asmd recipes.
tested in game, everything runs fine.