### PR TITLE
Parametrizer X Bugfix

### DIFF
--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/hatch/GT_MetaTileEntity_Hatch_Param.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/hatch/GT_MetaTileEntity_Hatch_Param.java
@@ -138,12 +138,12 @@ public class GT_MetaTileEntity_Hatch_Param extends GT_MetaTileEntity_Hatch {
     @Override
     public void saveNBTData(NBTTagCompound aNBT) {
         super.saveNBTData(aNBT);
-        aNBT.setLong("ePointer", pointer);
+        aNBT.setInteger("ePointer", pointer);
         aNBT.setDouble("eValue0D", value0D);
         aNBT.setDouble("eValue1D", value1D);
         aNBT.setDouble("eInput0D", input0D);
         aNBT.setDouble("eInput1D", input1D);
-        aNBT.setLong("eParam", param);
+        aNBT.setInteger("eParam", param);
     }
 
     @Override

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/hatch/GT_MetaTileEntity_Hatch_Param.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/hatch/GT_MetaTileEntity_Hatch_Param.java
@@ -138,12 +138,12 @@ public class GT_MetaTileEntity_Hatch_Param extends GT_MetaTileEntity_Hatch {
     @Override
     public void saveNBTData(NBTTagCompound aNBT) {
         super.saveNBTData(aNBT);
-        aNBT.setInteger("ePointer", pointer);
+        aNBT.setLong("ePointer", pointer);
         aNBT.setDouble("eValue0D", value0D);
         aNBT.setDouble("eValue1D", value1D);
         aNBT.setDouble("eInput0D", input0D);
         aNBT.setDouble("eInput1D", input1D);
-        aNBT.setInteger("eParam", param);
+        aNBT.setLong("eParam", param);
     }
 
     @Override
@@ -157,15 +157,15 @@ public class GT_MetaTileEntity_Hatch_Param extends GT_MetaTileEntity_Hatch {
                 aNBT.hasKey("eInput1i")){
             boolean usesFloat = aNBT.getBoolean("eFloats");
             if(usesFloat){
-                value0D=Float.intBitsToFloat(aNBT.getInteger("eValue0i"));
-                value1D=Float.intBitsToFloat(aNBT.getInteger("eValue1i"));
-                input0D=Float.intBitsToFloat(aNBT.getInteger("eInput0i"));
-                input1D=Float.intBitsToFloat(aNBT.getInteger("eInput1i"));
+                value0D=Double.longBitsToDouble(aNBT.getLong("eValue0i"));
+                value1D=Double.longBitsToDouble(aNBT.getLong("eValue1i"));
+                input0D=Double.longBitsToDouble(aNBT.getLong("eInput0i"));
+                input1D=Double.longBitsToDouble(aNBT.getLong("eInput1i"));
             }else {
-                value0D=aNBT.getInteger("eValue0i");
-                value1D=aNBT.getInteger("eValue1i");
-                input0D=aNBT.getInteger("eInput0i");
-                input1D=aNBT.getInteger("eInput1i");
+                value0D=aNBT.getLong("eValue0i");
+                value1D=aNBT.getLong("eValue1i");
+                input0D=aNBT.getLong("eInput0i");
+                input1D=aNBT.getLong("eInput1i");
             }
         }else{
             value0D=aNBT.getDouble("eValue0D");

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/hatch/gui/GT_Container_ParamAdv.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/hatch/gui/GT_Container_ParamAdv.java
@@ -92,11 +92,11 @@ public class GT_Container_ParamAdv extends GT_ContainerMetaTile_Machine {
                     } else {
                         if (secondRow) {
                             long temp=Double.doubleToLongBits(paramH.value1D);
-                            temp |= 1 << columnPointer;
+                            temp |= 1L << (long)columnPointer;
                             paramH.value1D=Double.longBitsToDouble(temp);
                         } else {
                             long temp=Double.doubleToLongBits(paramH.value0D);
-                            temp |= 1 << columnPointer;
+                            temp |= 1L << (long)columnPointer;
                             paramH.value0D=Double.longBitsToDouble(temp);
                         }
                     }
@@ -128,11 +128,11 @@ public class GT_Container_ParamAdv extends GT_ContainerMetaTile_Machine {
                     } else {
                         if (secondRow) {
                             long temp=Double.doubleToLongBits(paramH.value1D);
-                            temp &= ~(1 << columnPointer);
+                            temp &= ~(1L << (long)columnPointer);
                             paramH.value1D=Double.longBitsToDouble(temp);
                         } else {
                             long temp=Double.doubleToLongBits(paramH.value0D);
-                            temp &= ~(1 << columnPointer);
+                            temp &= ~(1L << (long)columnPointer);
                             paramH.value0D=Double.longBitsToDouble(temp);
                         }
                     }
@@ -185,11 +185,11 @@ public class GT_Container_ParamAdv extends GT_ContainerMetaTile_Machine {
                     } else {
                         if (secondRow) {
                             long temp=Double.doubleToLongBits(paramH.value1D);
-                            temp ^= 1 << columnPointer;
+                            temp ^= 1L << (long)columnPointer;
                             paramH.value1D=Double.longBitsToDouble(temp);
                         } else {
                             long temp=Double.doubleToLongBits(paramH.value0D);
-                            temp ^= 1 << columnPointer;
+                            temp ^= 1L << (long)columnPointer;
                             paramH.value0D=Double.longBitsToDouble(temp);
                         }
                     }
@@ -243,7 +243,7 @@ public class GT_Container_ParamAdv extends GT_ContainerMetaTile_Machine {
     @Override
     @SideOnly(Side.CLIENT)
     public void updateProgressBar(int par1, int par2) {
-        super.updateProgressBar(par1, par2);
+            super.updateProgressBar(par1, par2);
         switch (par1) {
             case 100:
             case 101:

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/hatch/gui/GT_Container_ParamAdv.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/hatch/gui/GT_Container_ParamAdv.java
@@ -243,7 +243,7 @@ public class GT_Container_ParamAdv extends GT_ContainerMetaTile_Machine {
     @Override
     @SideOnly(Side.CLIENT)
     public void updateProgressBar(int par1, int par2) {
-            super.updateProgressBar(par1, par2);
+        super.updateProgressBar(par1, par2);
         switch (par1) {
             case 100:
             case 101:


### PR DESCRIPTION
Added casts to long to fix overflow when doing the bit-manpulation. Doing this allows the Parametrizer X to work as intended.
Fix for issue [#GTNewHorizons/GT-New-Horizons-Modpack@10791 ](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/10791)