### PR TITLE
Change ender fluid link covers frequency to be text instead of a color hex

### DIFF
--- a/src/main/java/com/github/technus/tectech/mechanics/enderStorage/EnderLinkTag.java
+++ b/src/main/java/com/github/technus/tectech/mechanics/enderStorage/EnderLinkTag.java
@@ -2,22 +2,19 @@ package com.github.technus.tectech.mechanics.enderStorage;
 
 import com.google.common.base.Objects;
 
-import java.awt.*;
 import java.io.Serializable;
 import java.util.UUID;
 
 public class EnderLinkTag implements Serializable {
-    private final Color color;
+    private final String frequency;
     private final UUID player;
 
-    public EnderLinkTag(Color color, UUID player) {
-        this.color = color;
+    public EnderLinkTag(String frequency, UUID player) {
+        this.frequency = frequency;
         this.player = player;
     }
 
-    public int getColorInt() {
-        return color.getRGB();
-    }
+    public String getFrequency() { return frequency; }
 
     public UUID getUUID() {
         return player;
@@ -28,12 +25,12 @@ public class EnderLinkTag implements Serializable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         EnderLinkTag that = (EnderLinkTag) o;
-        return Objects.equal(color, that.color) &&
+        return Objects.equal(frequency, that.frequency) &&
                 Objects.equal(player, that.player);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(color, player);
+        return Objects.hashCode(frequency, player);
     }
 }

--- a/src/main/java/com/github/technus/tectech/mechanics/enderStorage/EnderWorldSavedData.java
+++ b/src/main/java/com/github/technus/tectech/mechanics/enderStorage/EnderWorldSavedData.java
@@ -6,7 +6,6 @@ import net.minecraft.world.storage.MapStorage;
 import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.fluids.IFluidHandler;
 
-import java.awt.*;
 import java.io.*;
 import java.util.HashMap;
 import java.util.Map;
@@ -19,7 +18,7 @@ public class EnderWorldSavedData extends WorldSavedData {
     private static final String DATA_NAME = MODID + "_EnderWorldSavedData";
     private static final String ENDER_LIQUID_TAG_LINK = DATA_NAME + "_EnderLiquidTagLink";
     private static final String ENDER_LIQUID_TANK_LINK = DATA_NAME + "_EnderLiquidTankLink";
-    private static final EnderLinkTag DEFAULT_LINK_TAG = new EnderLinkTag(Color.WHITE, null);
+    private static final EnderLinkTag DEFAULT_LINK_TAG = new EnderLinkTag("", null);
 
     private Map<EnderLinkTag, EnderFluidContainer> EnderLiquidTagLink = new HashMap<>();
     private Map<EnderLinkTank, EnderLinkTag> EnderLiquidTankLink = new HashMap<>();

--- a/src/main/java/com/github/technus/tectech/thing/cover/GT_Cover_TM_EnderFluidLink.java
+++ b/src/main/java/com/github/technus/tectech/thing/cover/GT_Cover_TM_EnderFluidLink.java
@@ -297,6 +297,5 @@ public class GT_Cover_TM_EnderFluidLink extends GT_CoverBehavior {
                 return true;
             }
         }
-
     }
 }

--- a/src/main/java/com/github/technus/tectech/thing/cover/GT_Cover_TM_EnderFluidLink.java
+++ b/src/main/java/com/github/technus/tectech/thing/cover/GT_Cover_TM_EnderFluidLink.java
@@ -3,7 +3,6 @@ package com.github.technus.tectech.thing.cover;
 import com.github.technus.tectech.loader.NetworkDispatcher;
 import com.github.technus.tectech.mechanics.enderStorage.EnderLinkCoverMessage;
 import com.github.technus.tectech.mechanics.enderStorage.EnderLinkTag;
-import com.github.technus.tectech.util.TT_Utility;
 import eu.usrv.yamcore.auxiliary.PlayerChatHelper;
 import gregtech.api.enums.GT_Values;
 import gregtech.api.gui.GT_GUICover;
@@ -22,7 +21,6 @@ import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.IFluidHandler;
 
-import java.awt.*;
 import java.util.UUID;
 
 import static com.github.technus.tectech.mechanics.enderStorage.EnderWorldSavedData.getEnderFluidContainer;
@@ -33,7 +31,7 @@ public class GT_Cover_TM_EnderFluidLink extends GT_CoverBehavior {
     private static final int L_PER_TICK = 8000;
     private final static int IMPORT_EXPORT_MASK = 0b0001;
     private final static int PUBLIC_PRIVATE_MASK = 0b0010;
-    private static EnderLinkTag tag = new EnderLinkTag(Color.WHITE, null);//Client-Sided
+    private static EnderLinkTag tag = new EnderLinkTag("", null);//Client-Sided
 
     public GT_Cover_TM_EnderFluidLink() {
     }
@@ -133,7 +131,7 @@ public class GT_Cover_TM_EnderFluidLink extends GT_CoverBehavior {
         private final byte side;
         private final int coverID;
         private int coverVariable;
-        private GT_GuiIntegerHexTextBox colorField;
+        private GT_GuiTextBox colorField;
 
         private final static int START_X = 10;
         private final static int START_Y = 25;
@@ -146,7 +144,7 @@ public class GT_Cover_TM_EnderFluidLink extends GT_CoverBehavior {
         private final static int BOX_SIZE_X = 34;
         private final static int BOX_SIZE_Y = 34;
 
-        private final static int TEXT_FIELD_SIZE_X = 72;
+        private final static int TEXT_FIELD_SIZE_X = SPACE_X * 5 - 8;
         private final static int TEXT_FIELD_SIZE_Y = 12;
         private final static int TEXT_STRING_LENGTH = 9;
 
@@ -163,8 +161,8 @@ public class GT_Cover_TM_EnderFluidLink extends GT_CoverBehavior {
             return new GT_GuiIconButton(this, id, START_X + SPACE_X * x, START_Y + SPACE_Y * y, icon);
         }
 
-        private GT_GuiIntegerHexTextBox newTextField(int id, int x, int y) {
-            GT_GuiIntegerHexTextBox field = new GT_GuiIntegerHexTextBox(this, id, START_X + SPACE_X * x,
+        private GT_GuiTextBox newTextField(int id, int x, int y) {
+            GT_GuiTextBox field = new GT_GuiTextBox(this, id, START_X + SPACE_X * x,
                     START_Y + SPACE_Y * y, TEXT_FIELD_SIZE_X, TEXT_FIELD_SIZE_Y);
             field.setMaxStringLength(TEXT_STRING_LENGTH);
             return field;
@@ -175,45 +173,6 @@ public class GT_Cover_TM_EnderFluidLink extends GT_CoverBehavior {
             return fontRendererObj.drawString(text, START_X + SPACE_X * x, align + START_Y + SPACE_Y * y, FONT_COLOR);
         }
 
-        private void drawColorSquare(int x, int y) {
-            //Draw the border square
-            int borderX1 = START_X + SPACE_X * x;
-            int borderY1 = START_Y + SPACE_Y * y;
-            int borderX2 = borderX1 + BOX_SIZE_X;
-            int borderY2 = borderY1 + BOX_SIZE_Y;
-            drawRect(borderX1, borderY1, borderX2, borderY2, BOX_BORDER_COLOR);
-
-            //Draw Checkerboard Pattern
-            int white = 0xFFFFFFFF;
-            int grey = 0xFFBFBFBF;
-            boolean whiteOrGrey = true;
-            int cGridXStart = borderX1 + 1;
-            int cGridYStart = borderY1 + 1;
-            int cGridXToDraw = 4;
-            int cGridYToDraw = 4;
-            int cSquareWidth = 8;
-            int cSquareHeight = 8;
-            for (int i = 0; i < cGridXToDraw; i++) {
-                for (int j = 0; j < cGridYToDraw; j++) {
-                    int cBoxX1 = cGridXStart + (cSquareWidth * i);
-                    int cBoxY1 = cGridYStart + (cSquareHeight * j);
-                    int cBoxX2 = cBoxX1 + cSquareWidth;
-                    int cBoxY2 = cBoxY1 + cSquareHeight;
-                    int cBoxColor = whiteOrGrey ? white : grey;
-                    drawRect(cBoxX1, cBoxY1, cBoxX2, cBoxY2, cBoxColor);
-                    whiteOrGrey = !whiteOrGrey;
-                }
-                whiteOrGrey = !whiteOrGrey;
-            }
-
-            //Draw the actual color
-            int insideX1 = borderX1 + 1;
-            int insideY1 = borderY1 + 1;
-            int insideX2 = borderX2 - 1;
-            int insideY2 = borderY2 - 1;
-            drawRect(insideX1, insideY1, insideX2, insideY2, tag.getColorInt());
-        }
-
         public TM_EnderFluidLinkCover(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) {
             super(aTileEntity, SIZE_X, SIZE_Y, GT_Utility.intToStack(aCoverID));
             side = aSide;
@@ -221,7 +180,7 @@ public class GT_Cover_TM_EnderFluidLink extends GT_CoverBehavior {
             coverVariable = aCoverVariable;
             NetworkDispatcher.INSTANCE.sendToServer(new EnderLinkCoverMessage.EnderLinkCoverQuery(tag, (IFluidHandler) tile));
             //Color Value Field
-            colorField = newTextField(COLOR_FIELD_ID, 2, 1);
+            colorField = newTextField(COLOR_FIELD_ID, 0, 0);
             GUI_INSTANCE = this;
             resetColorField();
             //Public/Private Buttons
@@ -239,8 +198,7 @@ public class GT_Cover_TM_EnderFluidLink extends GT_CoverBehavior {
         @Override
         public void drawExtras(int mouseX, int mouseY, float parTicks) {
             super.drawExtras(mouseX, mouseY, parTicks);
-            drawColorSquare(0, 0);
-            drawNewString(trans("328", "Color Value"), 2, 0);
+            drawNewString(trans("328", "Channel"), 5, 0);
             drawNewString(trans("329", "Public/Private"), 2, 2);
             drawNewString(trans("229", "Import/Export"), 2, 3);
         }
@@ -274,7 +232,7 @@ public class GT_Cover_TM_EnderFluidLink extends GT_CoverBehavior {
             } else {
                 ownerUUID = null;
             }
-            EnderLinkTag newTag = new EnderLinkTag(new Color(tag.getColorInt(), true), ownerUUID);
+            EnderLinkTag newTag = new EnderLinkTag(tag.getFrequency(), ownerUUID);
             NetworkDispatcher.INSTANCE.sendToServer(new EnderLinkCoverMessage.EnderLinkCoverUpdate(newTag, (IFluidHandler) tile));
         }
 
@@ -313,8 +271,7 @@ public class GT_Cover_TM_EnderFluidLink extends GT_CoverBehavior {
         public void applyTextBox(GT_GuiIntegerTextBox box) {
             try {
                 String string = box.getText();
-                int colorValue = (int) Long.parseLong(string.replaceFirst("#", ""), 16);
-                tag = new EnderLinkTag(new Color(colorValue, true), tag.getUUID());
+                tag = new EnderLinkTag(string, tag.getUUID());
                 NetworkDispatcher.INSTANCE.sendToServer(new EnderLinkCoverMessage.EnderLinkCoverUpdate(tag, (IFluidHandler) tile));
             } catch (NumberFormatException ignored) {
             }
@@ -323,31 +280,23 @@ public class GT_Cover_TM_EnderFluidLink extends GT_CoverBehavior {
 
         @Override
         public void resetTextBox(GT_GuiIntegerTextBox box) {
-            //Solid White becomes: #FFFFFFFF
-            box.setText("#" + TT_Utility.formatNumberIntHex(tag.getColorInt()));
+            box.setText(tag.getFrequency());
         }
 
         public void resetColorField() {
             resetTextBox(colorField);
         }
 
-        private class GT_GuiIntegerHexTextBox extends GT_GuiIntegerTextBox {
-            public GT_GuiIntegerHexTextBox(IGuiScreen gui, int id, int x, int y, int width, int height) {
+        private class GT_GuiTextBox extends GT_GuiIntegerTextBox {
+            public GT_GuiTextBox(IGuiScreen gui, int id, int x, int y, int width, int height) {
                 super(gui, id, x, y, width, height);
             }
 
             @Override
             public boolean validChar(char c, int key) {
-                boolean isValid;
-                if (getCursorPosition() == 0) {
-                    isValid = c == '#';
-                } else {
-                    isValid = super.validChar(c, key)
-                            || c == 'A' || c == 'B' || c == 'C' || c == 'D' || c == 'E' || c == 'F'
-                            || c == 'a' || c == 'b' || c == 'c' || c == 'd' || c == 'e' || c == 'f';
-                }
-                return isValid;
+                return true;
             }
         }
+
     }
 }


### PR DESCRIPTION
Change ender fluid link to use text instead of a color hex,
Breaks old setup but makes it easier to setup and remember channel names in the future