### PR TITLE
Remove the loss from buck converters

### DIFF
--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/single/GT_MetaTileEntity_BuckConverter.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/single/GT_MetaTileEntity_BuckConverter.java
@@ -111,15 +111,6 @@ public class GT_MetaTileEntity_BuckConverter extends GT_MetaTileEntity_TieredMac
     }
 
     @Override
-    public void onPreTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
-        if (aBaseMetaTileEntity.isServerSide() && (aTick & 0xF) == 0) {
-            if(aBaseMetaTileEntity.isActive()) {
-                aBaseMetaTileEntity.decreaseStoredEnergyUnits(CommonValues.V[EUT] >> 2, true);
-            }
-        }
-    }
-
-    @Override
     public boolean isFacingValid(byte aFacing) {
         return true;
     }

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/single/GT_MetaTileEntity_BuckConverter.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/single/GT_MetaTileEntity_BuckConverter.java
@@ -114,7 +114,7 @@ public class GT_MetaTileEntity_BuckConverter extends GT_MetaTileEntity_TieredMac
     public void onPreTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
         if (aBaseMetaTileEntity.isServerSide() && (aTick & 0xF) == 0) {
             if(aBaseMetaTileEntity.isActive()) {
-                aBaseMetaTileEntity.decreaseStoredEnergyUnits(CommonValues.V[mTier] >> 2, true);
+                aBaseMetaTileEntity.decreaseStoredEnergyUnits(CommonValues.V[EUT] >> 2, true);
             }
         }
     }


### PR DESCRIPTION
Currently Buck converters have a passive loss of 1A of the tier below. So a UV one has a passive loss of 1A ZPM when running. I think they shouldn't have a loss considering they're more expensive and can only take in 2A