### PR TITLE
Changed DEFC controller recipe and moved it to TecTech

### DIFF
--- a/src/main/java/com/github/technus/tectech/compatibility/dreamcraft/DreamCraftRecipeLoader.java
+++ b/src/main/java/com/github/technus/tectech/compatibility/dreamcraft/DreamCraftRecipeLoader.java
@@ -1393,7 +1393,7 @@ public class DreamCraftRecipeLoader {
                         ELEMENT.STANDALONE.ASTRAL_TITANIUM.getFluidStack(576),
                 }, GregtechItemList.Casing_Fusion_External.get(1), 300, 2000000);
 
-        // Draconic Evolution Fusion Controller controller
+        // Draconic Evolution Fusion Crafter Controller
 		if (Loader.isModLoaded("AWWayofTime")&&Loader.isModLoaded("EMT")){
 				TT_recipeAdder.addResearchableAssemblylineRecipe(GT_ModHandler.getModItem("EMT", "EMT_GTBLOCK_CASEING", 1, 8),
 						16_777_216, 1024, 2_000_000, 8, new Object[]{

--- a/src/main/java/com/github/technus/tectech/compatibility/dreamcraft/DreamCraftRecipeLoader.java
+++ b/src/main/java/com/github/technus/tectech/compatibility/dreamcraft/DreamCraftRecipeLoader.java
@@ -1411,7 +1411,7 @@ public class DreamCraftRecipeLoader {
 								new FluidStack(solderIndalloy, 2880),
 								Materials.Void.getMolten(2880L),
 								Materials.DraconiumAwakened.getMolten(1440),
-						}, DECC, 1500, 8_000_000);
+						}, GT_ModHandler.getModItem("gregtech", "gt.blockmachines", 1, 5001), 1500, 8_000_000);
 		}
 
         //region singleblocks

--- a/src/main/java/com/github/technus/tectech/compatibility/dreamcraft/DreamCraftRecipeLoader.java
+++ b/src/main/java/com/github/technus/tectech/compatibility/dreamcraft/DreamCraftRecipeLoader.java
@@ -1392,6 +1392,27 @@ public class DreamCraftRecipeLoader {
                         ELEMENT.STANDALONE.ASTRAL_TITANIUM.getFluidStack(576),
                 }, GregtechItemList.Casing_Fusion_External.get(1), 300, 2000000);
 
+        // Draconic Evolution Fusion Controller controller
+		if (Loader.isModLoaded("AWWayofTime")&&Loader.isModLoaded("EMT")){
+				TT_recipeAdder.addResearchableAssemblylineRecipe(GT_ModHandler.getModItem("EMT", "EMT_GTBLOCK_CASEING", 1, 8),
+						16_777_216, 1024, 2_000_000, 8, new Object[]{
+								GT_ModHandler.getModItem("gregtech", "gt.blockmachines", 1, 10783),
+								GT_ModHandler.getModItem("EMT", "EMT_GTBLOCK_CASEING", 1, 8),
+								GT_OreDictUnificator.get(OrePrefixes.plateDense, MaterialsBotania.GaiaSpirit, 1L),
+								ItemList.Casing_Coil_AwakenedDraconium.get(8L),
+								ItemList.Electric_Motor_UHV.get(8L),
+								ItemList.Robot_Arm_UHV.get(4L),
+								new Object[]{OrePrefixes.circuit.get(Materials.Infinite), 4},
+								ItemList.Gravistar.get(4, new Object(){}),
+								GT_ModHandler.getModItem("Thaumcraft", "ItemEldritchObject", 1, 3),
+								GT_ModHandler.getModItem("AWWayofTime", "bloodMagicBaseItems", 8, 29),
+								GT_ModHandler.getModItem("AWWayofTime", "bloodMagicBaseItems", 8, 28),
+						}, new FluidStack[]{
+								new FluidStack(solderIndalloy, 2880),
+								Materials.Void.getMolten(2880L),
+								Materials.DraconiumAwakened.getMolten(1440),
+						}, DECC, 1500, 8_000_000);
+		}
 
         //region singleblocks
 

--- a/src/main/java/com/github/technus/tectech/compatibility/dreamcraft/DreamCraftRecipeLoader.java
+++ b/src/main/java/com/github/technus/tectech/compatibility/dreamcraft/DreamCraftRecipeLoader.java
@@ -13,6 +13,7 @@ import gregtech.api.GregTech_API;
 import gregtech.api.enums.GT_Values;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
+import gregtech.api.enums.MaterialsBotania;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.interfaces.IItemContainer;
 import gregtech.api.util.GT_ModHandler;


### PR DESCRIPTION
Changed the recipe for the Draconic Evolution Fusion Crafter controller.

This multi is now the new method to obtain Draconic Cores and upgrade them. Further recipes are being added to it as well. As such it should not be tiered in LuV but in UHV, same as the old method.

I also added a primordial pearl and some BM Shards which were part of the old (soon to be removed) quest line directly to the controller recipe. Furthermore, I added a dense Gaia plate to improve botania integration into the pack.

However I have not added any HEE or any hard dependency on the T8 rocket (you still need UHV materials) which were both also part of the old method as those were generally disliked features. :)

The screenshot is with a texturepack but I hope thats clear anyway (thats a UHV assembler and UHV motors/robot arms)

![image](https://user-images.githubusercontent.com/40274384/183989698-0d0ecb00-d8d4-4ff7-964c-48149f8ef3e3.png)

Now also has research:
![image](https://user-images.githubusercontent.com/40274384/184024456-c2fde6a9-b6fc-4855-a5f3-602e9a8f2e4e.png)

old recipe removed here: https://github.com/GTNewHorizons/Electro-Magic-Tools/pull/42