### PR TITLE
Fix no Computation on world load

### DIFF
--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_EM_computer.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_EM_computer.java
@@ -40,6 +40,7 @@ import java.util.List;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.ResourceLocation;
 
@@ -175,6 +176,20 @@ public class GT_MetaTileEntity_EM_computer extends GT_MetaTileEntity_MultiblockB
             }
         }
         return eUncertainHatches.size() == 1;
+    }
+
+    @Override
+    public void saveNBTData(NBTTagCompound aNBT) {
+        super.saveNBTData(aNBT);
+        aNBT.setDouble("computation", availableData.get());
+    }
+
+    @Override
+    public void loadNBTData(NBTTagCompound aNBT) {
+        super.loadNBTData(aNBT);
+        if (availableData != null) {
+            availableData.set(aNBT.getDouble("computation"));
+        }
     }
 
     @Override


### PR DESCRIPTION
Added the computation of the Quantum Computer as NBT data. When the world is loaded it takes some time for the QC to fully go active. In the meantime machines like the Research station that depend on computation will shut off. With this change the QC still outputs the old amount of computation until it computed its current computation, which will make the Research Station not shut off due to the world loading.
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8725