### PR TITLE
Computation Timeout

### DIFF
--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_EM_computer.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_EM_computer.java
@@ -189,7 +189,7 @@ public class GT_MetaTileEntity_EM_computer extends GT_MetaTileEntity_MultiblockB
         super.loadNBTData(aNBT);
         if (availableData != null) {
             availableData.set(aNBT.getDouble("computation"));
-            eAvailableData = (long)availableData.get();
+            eAvailableData = (long) availableData.get();
         }
     }
 

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_EM_computer.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_EM_computer.java
@@ -189,6 +189,7 @@ public class GT_MetaTileEntity_EM_computer extends GT_MetaTileEntity_MultiblockB
         super.loadNBTData(aNBT);
         if (availableData != null) {
             availableData.set(aNBT.getDouble("computation"));
+            eAvailableData = (long)availableData.get();
         }
     }
 

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/base/GT_MetaTileEntity_MultiblockBase_EM.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/base/GT_MetaTileEntity_MultiblockBase_EM.java
@@ -118,6 +118,12 @@ public abstract class GT_MetaTileEntity_MultiblockBase_EM extends GT_MetaTileEnt
     // data required to operate
     protected long eRequiredData = 0;
 
+    // Counter for the computation timeout. Will be initialized one to the max time and then only decreased.
+    protected int eComputationTimeout = MAX_COMPUTATION_TIMEOUT;
+
+    // Max timeout of computation in ticks
+    protected static int MAX_COMPUTATION_TIMEOUT = 40;
+
     // storage for output EM that will be auto handled in case of failure to finish recipe
     // if you succed to use a recipe - be sure to output EM from outputEM to hatches in the output method
     protected EMInstanceStackMap[] outputEM;
@@ -1214,20 +1220,24 @@ public abstract class GT_MetaTileEntity_MultiblockBase_EM extends GT_MetaTileEnt
 
     public boolean onRunningTickCheck_EM(ItemStack aStack) {
         if (eRequiredData > eAvailableData) {
-            if (energyFlowOnRunningTick_EM(aStack, false)) {
-                stopMachine();
+            if (!checkComputationTimeout()) {
+                if (energyFlowOnRunningTick_EM(aStack, false)) {
+                    stopMachine();
+                }
+                return false;
             }
-            return false;
         }
         return energyFlowOnRunningTick_EM(aStack, true);
     }
 
     public boolean onRunningTickCheck(ItemStack aStack) {
         if (eRequiredData > eAvailableData) {
-            if (energyFlowOnRunningTick(aStack, false)) {
-                stopMachine();
+            if (!checkComputationTimeout()) {
+                if (energyFlowOnRunningTick(aStack, false)) {
+                    stopMachine();
+                }
+                return false;
             }
-            return false;
         }
         return energyFlowOnRunningTick(aStack, true);
     }
@@ -2880,5 +2890,16 @@ public abstract class GT_MetaTileEntity_MultiblockBase_EM extends GT_MetaTileEnt
         public IGT_HatchAdder<? super GT_MetaTileEntity_MultiblockBase_EM> adder() {
             return adder;
         }
+    }
+
+    /** Check if the computation timeout is still active
+     *
+     * @return True if the timeout is still active or false if the machine should fail
+     */
+    protected boolean checkComputationTimeout() {
+        if (eComputationTimeout > 0) {
+            return --eComputationTimeout > 0;
+        }
+        return false;
     }
 }

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/base/GT_MetaTileEntity_MultiblockBase_EM.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/base/GT_MetaTileEntity_MultiblockBase_EM.java
@@ -122,7 +122,7 @@ public abstract class GT_MetaTileEntity_MultiblockBase_EM extends GT_MetaTileEnt
     protected int eComputationTimeout = MAX_COMPUTATION_TIMEOUT;
 
     // Max timeout of computation in ticks
-    protected static int MAX_COMPUTATION_TIMEOUT = 40;
+    protected static int MAX_COMPUTATION_TIMEOUT = 100;
 
     // storage for output EM that will be auto handled in case of failure to finish recipe
     // if you succed to use a recipe - be sure to output EM from outputEM to hatches in the output method


### PR DESCRIPTION
Added a timeout to TT MB base so that machines dont stop after a world reload, as in some cases where the Research Station was loaded before the Quantum Computer, the Research could still fail. Now the Research Station waits a few ticks after the computation has cut off before it shuts off. 