### PR TITLE
Make UMV Wireless Energy/Dynamo hatches craftable

### DIFF
--- a/src/main/java/com/github/technus/tectech/compatibility/dreamcraft/DreamCraftRecipeLoader.java
+++ b/src/main/java/com/github/technus/tectech/compatibility/dreamcraft/DreamCraftRecipeLoader.java
@@ -5248,7 +5248,7 @@ public class DreamCraftRecipeLoader {
             new Object[] {OrePrefixes.circuit.get(Materials.Nano), 1L}, // UIV
             new Object[] {OrePrefixes.circuit.get(Materials.Piko), 1L}, // UMV
             new Object[] {OrePrefixes.circuit.get(Materials.Quantum), 1L}, // UXV
-            new Object[] {OrePrefixes.circuit.get(Materials.Transcendent), 1L}, // MAX
+            new Object[] {OrePrefixes.circuit.get(Materials.Quantum), 4L}, // MAX (Technically not MAX, can be changed once MAX circuits become craftable)
         };
 
         ItemStack[] wireless_hatches = {


### PR DESCRIPTION
MAX Circuits are very far away and UMV hatches in general are craftable, so why gate UMV wireless by unobtainable items?