### PR TITLE
Fix ME Stocking input bus dupe fix for all TT based MBs

### DIFF
--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/base/GT_MetaTileEntity_MultiblockBase_EM.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/base/GT_MetaTileEntity_MultiblockBase_EM.java
@@ -1143,7 +1143,9 @@ public abstract class GT_MetaTileEntity_MultiblockBase_EM extends GT_MetaTileEnt
     @Override
     public final boolean checkRecipe(ItemStack itemStack) { // do recipe checks, based on "machine content and state"
         hatchesStatusUpdate_EM();
+        startRecipeProcessing();
         boolean result = checkRecipe_EM(itemStack); // if had no - set default params
+        endRecipeProcessing();
         hatchesStatusUpdate_EM();
         return result;
     }


### PR DESCRIPTION
Added start and end processing calls like in the regulat MB base class, which will properly update the stocking input bus.

This is regarding https://github.com/GTNewHorizons/Dupes-Exploits-GTNH/issues/62

We'll need to update the tt dep of gg after merge