### PR TITLE
Use new API call instead of hack to prevent dropping of data sticks

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,7 +2,7 @@
 
 dependencies {
     shadowImplementation('com.github.GTNewHorizons:AVRcore:master-SNAPSHOT')
-    compile('com.github.GTNewHorizons:GT5-Unofficial:5.09.41.66:dev')
+    compile('com.github.GTNewHorizons:GT5-Unofficial:5.09.41.91-pre:dev')
     compile('com.github.GTNewHorizons:Yamcl:0.5.84:dev')
     compile('com.github.GTNewHorizons:NotEnoughItems:2.3.7-GTNH:dev')
     compile('com.github.GTNewHorizons:CodeChickenLib:1.1.5.5:dev')

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/hatch/GT_MetaTileEntity_Hatch_InputDataItems.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/hatch/GT_MetaTileEntity_Hatch_InputDataItems.java
@@ -201,13 +201,12 @@ public class GT_MetaTileEntity_Hatch_InputDataItems extends GT_MetaTileEntity_Ha
 
     @Override
     public ItemStack getStackInSlot(int aIndex) {
-        if (stacks == null || aIndex >= stacks.length) {
-            return null;
-        }
-        // We return a stack with size 0 to prevent dropping when the hatch is broken
-        ItemStack stackCopy = stacks[aIndex].copy();
-        stackCopy.stackSize = 0;
-        return stackCopy;
+        return stacks != null && aIndex < stacks.length ? stacks[aIndex] : null;
+    }
+
+    @Override
+    public boolean shouldDropItemAt(int index) {
+        return false;
     }
 
     @Override


### PR DESCRIPTION
Could possibly be the cause of https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11619