### PR TITLE
Added full block variant of all pipe types

### DIFF
--- a/src/main/java/com/github/technus/tectech/compatibility/dreamcraft/DreamCraftRecipeLoader.java
+++ b/src/main/java/com/github/technus/tectech/compatibility/dreamcraft/DreamCraftRecipeLoader.java
@@ -103,6 +103,14 @@ public class DreamCraftRecipeLoader {
                 200,
                 30720);
 
+        // Data Casing
+        addAssemblerRecipeWithCleanroom(
+                new ItemStack[] {CustomItemList.DATApipe.get(1), ItemList.Casing_LuV.get(1)},
+                null,
+                CustomItemList.DATApipeBlock.get(1),
+                20,
+                30720);
+
         // Tunnel
         addAssemblerRecipeWithCleanroom(
                 new ItemStack[] {
@@ -118,6 +126,14 @@ public class DreamCraftRecipeLoader {
                 400,
                 500000);
 
+        // Tunnel Casing
+        addAssemblerRecipeWithCleanroom(
+                new ItemStack[] {CustomItemList.EMpipe.get(1), ItemList.Casing_LuV.get(1)},
+                null,
+                CustomItemList.EMpipeBlock.get(1),
+                20,
+                30720);
+
         // Laser
         addAssemblerRecipeWithCleanroom(
                 new ItemStack[] {
@@ -129,6 +145,14 @@ public class DreamCraftRecipeLoader {
                 CustomItemList.LASERpipe.get(1),
                 100,
                 500000);
+
+        // Laser Casing
+        addAssemblerRecipeWithCleanroom(
+                new ItemStack[] {CustomItemList.LASERpipe.get(1), ItemList.Casing_LuV.get(1)},
+                null,
+                CustomItemList.LASERpipeBlock.get(1),
+                20,
+                30720);
 
         // endregion
 

--- a/src/main/java/com/github/technus/tectech/loader/thing/MachineLoader.java
+++ b/src/main/java/com/github/technus/tectech/loader/thing/MachineLoader.java
@@ -12,9 +12,7 @@ import com.github.technus.tectech.thing.metaTileEntity.hatch.*;
 import com.github.technus.tectech.thing.metaTileEntity.multi.*;
 import com.github.technus.tectech.thing.metaTileEntity.multi.em_collider.GT_MetaTileEntity_EM_collider;
 import com.github.technus.tectech.thing.metaTileEntity.multi.em_machine.GT_MetaTileEntity_EM_machine;
-import com.github.technus.tectech.thing.metaTileEntity.pipe.GT_MetaTileEntity_Pipe_Data;
-import com.github.technus.tectech.thing.metaTileEntity.pipe.GT_MetaTileEntity_Pipe_EM;
-import com.github.technus.tectech.thing.metaTileEntity.pipe.GT_MetaTileEntity_Pipe_Energy;
+import com.github.technus.tectech.thing.metaTileEntity.pipe.*;
 import com.github.technus.tectech.thing.metaTileEntity.single.*;
 import cpw.mods.fml.common.Loader;
 import net.minecraft.init.Blocks;
@@ -899,6 +897,15 @@ public class MachineLoader implements Runnable {
         LASERpipe.set(
                 new GT_MetaTileEntity_Pipe_Energy(15465, "pipe.energystream", "Laser Vacuum Pipe").getStackForm(1L));
         DATApipe.set(new GT_MetaTileEntity_Pipe_Data(15470, "pipe.datastream", "Optical Fiber Cable").getStackForm(1L));
+        EMpipeBlock.set(
+                new GT_MetaTileEntity_PipeBlock_EM(15471, "pipe.elementalmatter.block", "Quantum \"Tunnel\" Casing")
+                        .getStackForm(1L));
+        LASERpipeBlock.set(
+                new GT_MetaTileEntity_PipeBlock_Energy(15472, "pipe.energystream.block", "Laser Vacuum Pipe Casing")
+                        .getStackForm(1L));
+        DATApipeBlock.set(
+                new GT_MetaTileEntity_PipeBlock_Data(15473, "pipe.datastream.block", "Optical Fiber Cable Casing")
+                        .getStackForm(1L));
 
         // ===================================================================================================
         // Single Blocks

--- a/src/main/java/com/github/technus/tectech/thing/CustomItemList.java
+++ b/src/main/java/com/github/technus/tectech/thing/CustomItemList.java
@@ -388,7 +388,10 @@ public enum CustomItemList implements IItemContainer {
     Machine_TeslaCoil_4by4_MV,
     Machine_TeslaCoil_4by4_HV,
     Machine_TeslaCoil_4by4_EV,
-    Machine_TeslaCoil_4by4_IV;
+    Machine_TeslaCoil_4by4_IV,
+    DATApipeBlock,
+    EMpipeBlock,
+    LASERpipeBlock;
 
     private ItemStack mStack;
     private boolean mHasNotBeenSet = true;

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/pipe/GT_MetaTileEntity_PipeBlock_Data.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/pipe/GT_MetaTileEntity_PipeBlock_Data.java
@@ -1,0 +1,32 @@
+package com.github.technus.tectech.thing.metaTileEntity.pipe;
+
+import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
+import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+import net.minecraft.util.AxisAlignedBB;
+import net.minecraft.world.World;
+
+public class GT_MetaTileEntity_PipeBlock_Data extends GT_MetaTileEntity_Pipe_Data {
+
+    public GT_MetaTileEntity_PipeBlock_Data(int aID, String aName, String aNameRegional) {
+        super(aID, aName, aNameRegional);
+    }
+
+    public GT_MetaTileEntity_PipeBlock_Data(String aName) {
+        super(aName);
+    }
+
+    @Override
+    public IMetaTileEntity newMetaEntity(IGregTechTileEntity iGregTechTileEntity) {
+        return new GT_MetaTileEntity_PipeBlock_Data(mName);
+    }
+
+    @Override
+    public AxisAlignedBB getCollisionBoundingBoxFromPool(World aWorld, int aX, int aY, int aZ) {
+        return AxisAlignedBB.getBoundingBox(aX, aY, aZ, aX + 1, aY + 1, aZ + 1);
+    }
+
+    @Override
+    public float getThickNess() {
+        return 1f;
+    }
+}

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/pipe/GT_MetaTileEntity_PipeBlock_EM.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/pipe/GT_MetaTileEntity_PipeBlock_EM.java
@@ -1,0 +1,32 @@
+package com.github.technus.tectech.thing.metaTileEntity.pipe;
+
+import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
+import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+import net.minecraft.util.AxisAlignedBB;
+import net.minecraft.world.World;
+
+public class GT_MetaTileEntity_PipeBlock_EM extends GT_MetaTileEntity_Pipe_EM {
+
+    public GT_MetaTileEntity_PipeBlock_EM(int aID, String aName, String aNameRegional) {
+        super(aID, aName, aNameRegional);
+    }
+
+    public GT_MetaTileEntity_PipeBlock_EM(String aName) {
+        super(aName);
+    }
+
+    @Override
+    public IMetaTileEntity newMetaEntity(IGregTechTileEntity iGregTechTileEntity) {
+        return new GT_MetaTileEntity_PipeBlock_EM(mName);
+    }
+
+    @Override
+    public AxisAlignedBB getCollisionBoundingBoxFromPool(World aWorld, int aX, int aY, int aZ) {
+        return AxisAlignedBB.getBoundingBox(aX, aY, aZ, aX + 1, aY + 1, aZ + 1);
+    }
+
+    @Override
+    public float getThickNess() {
+        return 1f;
+    }
+}

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/pipe/GT_MetaTileEntity_PipeBlock_Energy.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/pipe/GT_MetaTileEntity_PipeBlock_Energy.java
@@ -1,0 +1,32 @@
+package com.github.technus.tectech.thing.metaTileEntity.pipe;
+
+import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
+import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+import net.minecraft.util.AxisAlignedBB;
+import net.minecraft.world.World;
+
+public class GT_MetaTileEntity_PipeBlock_Energy extends GT_MetaTileEntity_Pipe_Energy {
+
+    public GT_MetaTileEntity_PipeBlock_Energy(int aID, String aName, String aNameRegional) {
+        super(aID, aName, aNameRegional);
+    }
+
+    public GT_MetaTileEntity_PipeBlock_Energy(String aName) {
+        super(aName);
+    }
+
+    @Override
+    public IMetaTileEntity newMetaEntity(IGregTechTileEntity iGregTechTileEntity) {
+        return new GT_MetaTileEntity_PipeBlock_Energy(mName);
+    }
+
+    @Override
+    public AxisAlignedBB getCollisionBoundingBoxFromPool(World aWorld, int aX, int aY, int aZ) {
+        return AxisAlignedBB.getBoundingBox(aX, aY, aZ, aX + 1, aY + 1, aZ + 1);
+    }
+
+    @Override
+    public float getThickNess() {
+        return 1f;
+    }
+}


### PR DESCRIPTION
Added a full block pipe variant to fix visual issues like:

![](https://cdn.discordapp.com/attachments/744192120742740039/1035232562945200198/unknown.png)

by adding:

![](https://cdn.discordapp.com/attachments/744192120742740039/1035234892696530964/unknown.png)