### PR TITLE
Fix persistant ender link data bug

### DIFF
--- a/src/main/java/com/github/technus/tectech/TecTech.java
+++ b/src/main/java/com/github/technus/tectech/TecTech.java
@@ -18,6 +18,7 @@ import com.github.technus.tectech.mechanics.elementalMatter.core.commands.EMGive
 import com.github.technus.tectech.mechanics.elementalMatter.core.commands.EMList;
 import com.github.technus.tectech.mechanics.elementalMatter.core.definitions.registry.EMDefinitionsRegistry;
 import com.github.technus.tectech.mechanics.elementalMatter.core.transformations.EMTransformationRegistry;
+import com.github.technus.tectech.mechanics.enderStorage.EnderWorldSavedData;
 import com.github.technus.tectech.proxy.CommonProxy;
 import com.github.technus.tectech.util.XSTR;
 import cpw.mods.fml.common.FMLCommonHandler;
@@ -59,6 +60,7 @@ public class TecTech {
     private static IngameErrorLog moduleAdminErrorLogs;
     public static TecTechConfig configTecTech;
 
+    public static EnderWorldSavedData enderWorldSavedData;
     public static ChunkDataHandler chunkDataHandler;
     public static AnomalyHandler anomalyHandler;
     public static PlayerPersistence playerPersistence;
@@ -107,6 +109,10 @@ public class TecTech {
         chunkDataHandler = new ChunkDataHandler();
         FMLCommonHandler.instance().bus().register(chunkDataHandler);
         MinecraftForge.EVENT_BUS.register(chunkDataHandler);
+
+        enderWorldSavedData = new EnderWorldSavedData();
+        FMLCommonHandler.instance().bus().register(enderWorldSavedData);
+        MinecraftForge.EVENT_BUS.register(enderWorldSavedData);
 
         MainLoader.preLoad();
     }

--- a/src/main/java/com/github/technus/tectech/mechanics/enderStorage/EnderWorldSavedData.java
+++ b/src/main/java/com/github/technus/tectech/mechanics/enderStorage/EnderWorldSavedData.java
@@ -129,13 +129,6 @@ public class EnderWorldSavedData extends WorldSavedData {
         getEnderLiquidTankLink().put(tank, tag);
     }
 
-    public static void initiate() {
-        if (!initiated) {
-            initiated = true;
-            MinecraftForge.EVENT_BUS.register(new EnderWorldSavedData());
-        }
-    }
-
     @SubscribeEvent
     public void onWorldUnload(WorldEvent.Unload event) {
         INSTANCE = null;

--- a/src/main/java/com/github/technus/tectech/mechanics/enderStorage/EnderWorldSavedData.java
+++ b/src/main/java/com/github/technus/tectech/mechanics/enderStorage/EnderWorldSavedData.java
@@ -10,7 +10,6 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.WorldSavedData;
 import net.minecraft.world.storage.MapStorage;
 import net.minecraftforge.common.DimensionManager;
-import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fluids.IFluidHandler;
 

--- a/src/main/java/com/github/technus/tectech/mechanics/enderStorage/EnderWorldSavedData.java
+++ b/src/main/java/com/github/technus/tectech/mechanics/enderStorage/EnderWorldSavedData.java
@@ -2,6 +2,7 @@ package com.github.technus.tectech.mechanics.enderStorage;
 
 import static com.github.technus.tectech.Reference.MODID;
 
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import java.io.*;
 import java.util.HashMap;
 import java.util.Map;
@@ -9,10 +10,13 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.WorldSavedData;
 import net.minecraft.world.storage.MapStorage;
 import net.minecraftforge.common.DimensionManager;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fluids.IFluidHandler;
 
 public class EnderWorldSavedData extends WorldSavedData {
     private static EnderWorldSavedData INSTANCE;
+    private static boolean initiated = false;
 
     private static final String DATA_NAME = MODID + "_EnderWorldSavedData";
     private static final String ENDER_LIQUID_TAG_LINK = DATA_NAME + "_EnderLiquidTagLink";
@@ -123,5 +127,17 @@ public class EnderWorldSavedData extends WorldSavedData {
         EnderLinkTank tank = new EnderLinkTank(handler);
         getEnderLiquidTankLink().remove(tank);
         getEnderLiquidTankLink().put(tank, tag);
+    }
+
+    public static void initiate() {
+        if (!initiated) {
+            initiated = true;
+            MinecraftForge.EVENT_BUS.register(new EnderWorldSavedData());
+        }
+    }
+
+    @SubscribeEvent
+    public void onWorldUnload(WorldEvent.Unload event) {
+        INSTANCE = null;
     }
 }

--- a/src/main/java/com/github/technus/tectech/mechanics/enderStorage/EnderWorldSavedData.java
+++ b/src/main/java/com/github/technus/tectech/mechanics/enderStorage/EnderWorldSavedData.java
@@ -16,7 +16,6 @@ import net.minecraftforge.fluids.IFluidHandler;
 
 public class EnderWorldSavedData extends WorldSavedData {
     private static EnderWorldSavedData INSTANCE;
-    private static boolean initiated = false;
 
     private static final String DATA_NAME = MODID + "_EnderWorldSavedData";
     private static final String ENDER_LIQUID_TAG_LINK = DATA_NAME + "_EnderLiquidTagLink";


### PR DESCRIPTION
Currently when you create world A, set up the fluid cover and fill it with fluid. Then enter world B, set up the same frequency, you would be able to transfer the fluid from save A to B. This is now fixed by invalidating the Fluid Cover map on world unload.