### PR TITLE
Feature/longPowerBase

### DIFF
--- a/src/main/java/com/github/technus/tectech/compatibility/dreamcraft/DreamCraftRecipeLoader.java
+++ b/src/main/java/com/github/technus/tectech/compatibility/dreamcraft/DreamCraftRecipeLoader.java
@@ -5333,7 +5333,7 @@ public class DreamCraftRecipeLoader {
                 ? FluidRegistry.getFluid("molten.mutatedlivingsolder")
                 : FluidRegistry.getFluid("molten.solderingalloy");
 
-        ItemStack largeShirabonPlate = Loader.isModLoaded("TinkersGregworks")
+        ItemStack largeShirabonPlate = Loader.isModLoaded("TGregworks")
                 ? TGregUtils.newItemStack(Materials.get("Shirabon"), PartTypes.LargePlate, 1)
                 : GT_OreDictUnificator.get("plateDenseShirabon", 1);
 

--- a/src/main/java/com/github/technus/tectech/compatibility/dreamcraft/DreamCraftRecipeLoader.java
+++ b/src/main/java/com/github/technus/tectech/compatibility/dreamcraft/DreamCraftRecipeLoader.java
@@ -5333,7 +5333,9 @@ public class DreamCraftRecipeLoader {
                 ? FluidRegistry.getFluid("molten.mutatedlivingsolder")
                 : FluidRegistry.getFluid("molten.solderingalloy");
 
-        ItemStack largeShirabonPlate = TGregUtils.newItemStack(Materials.get("Shirabon"), PartTypes.LargePlate, 1);
+        ItemStack largeShirabonPlate = Loader.isModLoaded("TinkersGregworks")
+                ? TGregUtils.newItemStack(Materials.get("Shirabon"), PartTypes.LargePlate, 1)
+                : GT_OreDictUnificator.get("plateDenseShirabon", 1);
 
         final FluidStack[] specialFluid = new FluidStack[] { Materials.SpaceTime.getMolten(1_440),
                 Materials.SpaceTime.getMolten(1_440), Materials.SpaceTime.getMolten(1_440),


### PR DESCRIPTION
- Added check if TGregworks is present before getting large shirabon plate from it, so it doesn't become a hard dep of TT
- Migrated to long power base. As of now the multis will still use and support `mEUt`, but can me switched to `lEUt` by setting the flag `useLongPower` to true in the constructor.
- Some methods were removed, because they are already defined in the now used super. The content of the functions is the same.

Tested in full pack by Lewis