### PR TITLE
Remove Mistake in description of Energy Infuser

### DIFF
--- a/src/main/resources/assets/tectech/lang/en_US.lang
+++ b/src/main/resources/assets/tectech/lang/en_US.lang
@@ -687,7 +687,7 @@ gt.blockmachines.multimachine.em.infuser.desc.1=Can be used to charge items (los
 gt.blockmachines.multimachine.em.infuser.desc.2=Can be fed with UU-Matter to repair items
 gt.blockmachines.multimachine.em.infuser.Structure.HighPowerCasing=Layer 1 and 5
 gt.blockmachines.multimachine.em.infuser.Structure.MolecularCoil=Layer 2 and 4
-gt.blockmachines.multimachine.em.infuser.Structure.MolecularCasing=Layer 3 (hollow)
+gt.blockmachines.multimachine.em.infuser.Structure.MolecularCasing=Layer 3
 
 
 gt.blockmachines.multimachine.em.processing.name=Quantum Processing Machine


### PR DESCRIPTION
Its not hollow
![image](https://user-images.githubusercontent.com/39595617/222515851-2977a431-61ab-4621-b641-27feb6f86093.png)
![image](https://user-images.githubusercontent.com/39595617/222516008-e4aa7e12-d6ab-483f-bff8-6dc438a067c8.png)
