### PR TITLE
Fix plate amount in UXV sensor recipe

### DIFF
--- a/src/main/java/com/github/technus/tectech/compatibility/dreamcraft/DreamCraftRecipeLoader.java
+++ b/src/main/java/com/github/technus/tectech/compatibility/dreamcraft/DreamCraftRecipeLoader.java
@@ -5235,7 +5235,7 @@ public class DreamCraftRecipeLoader {
                                 .get(OrePrefixes.frameGt, Materials.MagnetohydrodynamicallyConstrainedStarMatter, 1L),
                         ItemList.Electric_Motor_UXV.get(1L),
                         GT_OreDictUnificator
-                                .get(OrePrefixes.plate, Materials.MagnetohydrodynamicallyConstrainedStarMatter, 16L),
+                                .get(OrePrefixes.plate, Materials.MagnetohydrodynamicallyConstrainedStarMatter, 8L),
                         ItemList.NuclearStar.get(16), new Object[] { OrePrefixes.circuit.get(Materials.Quantum), 4L },
                         GT_OreDictUnificator
                                 .get(OrePrefixes.foil, Materials.MagnetohydrodynamicallyConstrainedStarMatter, 64),


### PR DESCRIPTION
The UXV sensor requires 16 plates, while all other LuV+ sensors require 8
This PR reduces the plate amount to 8 to match the other sensors
![image](https://user-images.githubusercontent.com/93287602/222858860-8150f8e8-bcd2-417a-ae5f-e98f4cda24af.png)
![image](https://user-images.githubusercontent.com/93287602/222858946-ce412311-0754-482f-a792-3487fc0f5e8a.png)
