### PR TITLE
Fix digital singularity amounts in spacetime compression field gens

### DIFF
--- a/src/main/java/com/github/technus/tectech/compatibility/dreamcraft/DreamCraftRecipeLoader.java
+++ b/src/main/java/com/github/technus/tectech/compatibility/dreamcraft/DreamCraftRecipeLoader.java
@@ -5557,8 +5557,7 @@ public class DreamCraftRecipeLoader {
                                 getModItem("avaritiaddons", "InfinityChest", absoluteTier + 1),
                                 // Cosmic fabric manipulator
                                 getModItem("miscutils", "gtplusplus.blockcasings.5", tier, 8), ME_Singularity,
-                                ME_Singularity, ME_Singularity, plateList[absoluteTier],
-                                getItemContainer("QuantumCircuit").get(set) },
+                                ME_Singularity, plateList[absoluteTier], getItemContainer("QuantumCircuit").get(set) },
                         new FluidStack[] { new FluidStack(solderUEV, (int) (2_880 * pow(2L, absoluteTier))),
                                 Materials.Space.getMolten(1_440 * (absoluteTier + 1)), specialFluid[absoluteTier] },
                         CustomItemList.SpacetimeCompressionFieldGeneratorTier1.get(1),
@@ -5582,7 +5581,7 @@ public class DreamCraftRecipeLoader {
                                 getModItem("avaritiaddons", "InfinityChest", absoluteTier + 1),
                                 // Cosmic fabric manipulator
                                 getModItem("miscutils", "gtplusplus.blockcasings.5", tier, 8), ME_Singularity,
-                                ME_Singularity, ME_Singularity, ME_Singularity, plateList[absoluteTier],
+                                ME_Singularity, ME_Singularity, plateList[absoluteTier],
                                 getItemContainer("QuantumCircuit").get(set) },
                         new FluidStack[] { new FluidStack(solderUEV, (int) (2_880 * pow(2L, absoluteTier))),
                                 Materials.Space.getMolten(1_440 * (absoluteTier + 1)), specialFluid[absoluteTier], },


### PR DESCRIPTION
The number of digital singularities used in the first 4 tiers was 1, 3, 4, 4
changed it to 1, 2, 3, 4