### PR TITLE
Fusion mk5 recipes + mk4 recipe fix

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -11,7 +11,7 @@ dependencies {
 
     compileOnly('com.github.GTNewHorizons:OpenModularTurrets:2.2.11-247:dev') {transitive=false}
     compileOnly('com.github.GTNewHorizons:OpenComputers:1.8.0.9-GTNH:dev') {transitive=false}
-    compileOnly('com.github.GTNewHorizons:GTplusplus:1.7.213:dev') {transitive=false}
+    compileOnly('com.github.GTNewHorizons:GTplusplus:1.8.35:dev') {transitive=false}
 
     compileOnly('curse.maven:cofh-lib-220333:2388748') {transitive=false}
     compileOnly('curse.maven:computercraft-67504:2269339') {transitive=false}

--- a/src/main/java/com/github/technus/tectech/loader/recipe/ResearchStationAssemblyLine.java
+++ b/src/main/java/com/github/technus/tectech/loader/recipe/ResearchStationAssemblyLine.java
@@ -1212,6 +1212,66 @@ public class ResearchStationAssemblyLine implements Runnable {
                     GregtechItemList.Casing_Fusion_External.get(1),
                     300,
                     2000000);
+
+            // MK5 Computer
+            TT_recipeAdder.addResearchableAssemblylineRecipe(
+                    GregtechItemList.FusionComputer_UV2.get(1),
+                    2560000,
+                    4096,
+                    (int) TierEU.RECIPE_UEV,
+                    8,
+                    new Object[] { GregtechItemList.Casing_Fusion_Internal2.get(1),
+                            new Object[] { OrePrefixes.circuit.get(Materials.Optical), 1L },
+                            new Object[] { OrePrefixes.circuit.get(Materials.Optical), 1L },
+                            new Object[] { OrePrefixes.circuit.get(Materials.Optical), 1L },
+                            new Object[] { OrePrefixes.circuit.get(Materials.Optical), 1L },
+                            GT_OreDictUnificator.get("plateDenseMetastableOganesson", 4),
+                            ItemList.Field_Generator_UEV.get(2), getItemContainer("PicoWafer").get(64L),
+                            GT_OreDictUnificator.get(OrePrefixes.wireGt04, Materials.SuperconductorUEV, 32) },
+                    new FluidStack[] { ELEMENT.getInstance().CURIUM.getFluidStack(9216),
+                            ELEMENT.STANDALONE.CHRONOMATIC_GLASS.getFluidStack(9216), ALLOY.ABYSSAL.getFluidStack(9216),
+                            ELEMENT.STANDALONE.DRAGON_METAL.getFluidStack(9216) },
+                    GregtechItemList.FusionComputer_UV3.get(1),
+                    6000,
+                    (int) TierEU.RECIPE_UEV);
+
+            // MK5 Coils
+            TT_recipeAdder.addResearchableAssemblylineRecipe(
+                    GregtechItemList.Casing_Fusion_Internal.get(1),
+                    2560000,
+                    4096,
+                    (int) TierEU.RECIPE_UEV,
+                    8,
+                    new Object[] { ItemList.Energy_Module.get(16),
+                            new Object[] { OrePrefixes.circuit.get(Materials.Ultimate), 16L },
+                            new Object[] { OrePrefixes.circuit.get(Materials.Infinite), 8L },
+                            ELEMENT.STANDALONE.RHUGNOR.getPlate(8), ItemList.Emitter_UEV.get(1),
+                            ItemList.Sensor_UEV.get(1), getModItem(GoodGenerator.ID, "compactFusionCoil", 1, 2) },
+                    new FluidStack[] { ELEMENT.getInstance().NEPTUNIUM.getFluidStack(2304),
+                            ELEMENT.STANDALONE.CHRONOMATIC_GLASS.getFluidStack(2304), ALLOY.ABYSSAL.getFluidStack(2304),
+                            ELEMENT.STANDALONE.DRAGON_METAL.getFluidStack(2304) },
+                    GregtechItemList.Casing_Fusion_Internal2.get(1),
+                    1200,
+                    (int) TierEU.RECIPE_UEV);
+
+            // MK5 Casing
+            TT_recipeAdder.addResearchableAssemblylineRecipe(
+                    GregtechItemList.Casing_Fusion_External.get(1L),
+                    2560000,
+                    4096,
+                    (int) TierEU.RECIPE_UEV,
+                    8,
+                    new Object[] { new Object[] { OrePrefixes.circuit.get(Materials.Elite), 16L },
+                            new Object[] { OrePrefixes.circuit.get(Materials.Master), 8L },
+                            GT_OreDictUnificator.get(OrePrefixes.block, Materials.NaquadahAlloy, 8),
+                            ELEMENT.STANDALONE.CHRONOMATIC_GLASS.getPlate(8), ItemList.Electric_Motor_UEV.get(2),
+                            ItemList.Electric_Piston_UEV.get(1), GregtechItemList.Casing_Fusion_External.get(1L) },
+                    new FluidStack[] { ELEMENT.getInstance().FERMIUM.getFluidStack(1152),
+                            ELEMENT.STANDALONE.CHRONOMATIC_GLASS.getFluidStack(1152), ALLOY.ABYSSAL.getFluidStack(1152),
+                            ELEMENT.STANDALONE.DRAGON_METAL.getFluidStack(1152) },
+                    GregtechItemList.Casing_Fusion_External2.get(1),
+                    300,
+                    (int) TierEU.RECIPE_UEV);
         }
 
         // Draconic Evolution Fusion Crafter Controller

--- a/src/main/java/com/github/technus/tectech/loader/recipe/ResearchStationAssemblyLine.java
+++ b/src/main/java/com/github/technus/tectech/loader/recipe/ResearchStationAssemblyLine.java
@@ -1165,8 +1165,7 @@ public class ResearchStationAssemblyLine implements Runnable {
                             new Object[] { OrePrefixes.circuit.get(Materials.Bio), 1L },
                             GT_OreDictUnificator.get(OrePrefixes.plateDense, Materials.Neutronium, 4),
                             ItemList.Field_Generator_UHV.get(2), ItemList.Circuit_Wafer_QPIC.get(64),
-                            GT_OreDictUnificator
-                                    .get(OrePrefixes.wireGt04, Materials.SuperconductorUHV, 32), },
+                            GT_OreDictUnificator.get(OrePrefixes.wireGt04, Materials.SuperconductorUHV, 32) },
                     new FluidStack[] { Materials.UUMatter.getFluid(50000), ALLOY.CINOBITE.getFluidStack(9216),
                             ALLOY.OCTIRON.getFluidStack(9216),
                             ELEMENT.STANDALONE.ASTRAL_TITANIUM.getFluidStack(9216), },

--- a/src/main/java/com/github/technus/tectech/loader/recipe/ResearchStationAssemblyLine.java
+++ b/src/main/java/com/github/technus/tectech/loader/recipe/ResearchStationAssemblyLine.java
@@ -1166,7 +1166,7 @@ public class ResearchStationAssemblyLine implements Runnable {
                             GT_OreDictUnificator.get(OrePrefixes.plateDense, Materials.Neutronium, 4),
                             ItemList.Field_Generator_UHV.get(2), ItemList.Circuit_Wafer_QPIC.get(64),
                             GT_OreDictUnificator
-                                    .get(OrePrefixes.wireGt04, Materials.Longasssuperconductornameforuhvwire, 32), },
+                                    .get(OrePrefixes.wireGt04, Materials.SuperconductorUHV, 32), },
                     new FluidStack[] { Materials.UUMatter.getFluid(50000), ALLOY.CINOBITE.getFluidStack(9216),
                             ALLOY.OCTIRON.getFluidStack(9216),
                             ELEMENT.STANDALONE.ASTRAL_TITANIUM.getFluidStack(9216), },


### PR DESCRIPTION
This PR adds recipes for the mk5 fusion controller, casing and coil.
Also fixes the fusion mk4 controller recipe using sc base uhv instead of sc uhv.

Controller:
![image](https://user-images.githubusercontent.com/93287602/231566250-319d824c-33c3-40e6-a599-e4d6775c5b5e.png)

Coil:
![image](https://user-images.githubusercontent.com/93287602/231566394-2a598e67-e7dc-4c6a-ade7-936761cf4e56.png)

Casing:
![image](https://user-images.githubusercontent.com/93287602/231566496-185097a5-2e01-4566-879d-c02fc1245ded.png)
