### PR TITLE
Adjust ev multiamp hatch recipes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1682616243
+//version: 1683056771
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -71,6 +71,9 @@ plugins {
     id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
     id 'com.gtnewhorizons.retrofuturagradle' version '1.3.7'
 }
+
+print("You might want to check out './gradlew :faq' if your build fails.")
+
 boolean settingsupdated = verifySettingsGradle()
 settingsupdated = verifyGitAttributes() || settingsupdated
 if (settingsupdated)
@@ -1249,6 +1252,19 @@ if (!project.getGradle().startParameter.isOffline() && !Boolean.getBoolean('DISA
         if (gradle.gradleVersion != buildscriptGradleVersion) {
             out.style(Style.SuccessHeader).println("updateBuildScript can update gradle from ${gradle.gradleVersion} to ${buildscriptGradleVersion}\n")
         }
+    }
+}
+
+// If you want to add more cases to this task, implement them as arguments if total amount to print gets too large
+tasks.register('faq') {
+    group = 'GTNH Buildscript'
+    description = 'Prints frequently asked questions about building a project'
+
+    doLast {
+        print("If your build fails to fetch dependencies, they might have been deleted and replaced by newer " +
+            "versions.\nCheck if the versions you try to fetch are still on the distributing sites.\n" +
+            "The links can be found in repositories.gradle and build.gradle:repositories, " +
+            "not build.gradle:buildscript.repositories - this one is for gradle plugin metadata.")
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/github/technus/tectech/loader/recipe/Assembler.java
+++ b/src/main/java/com/github/technus/tectech/loader/recipe/Assembler.java
@@ -320,7 +320,7 @@ public class Assembler implements Runnable {
             {
                 // Dynamo EV 16A
                 GT_Values.RA.addAssemblerRecipe(
-                        new ItemStack[] { CustomItemList.eM_dynamoMulti4_EV.get(1),
+                        new ItemStack[] { ItemList.Transformer_IV_EV.get(1), CustomItemList.eM_dynamoMulti4_EV.get(1),
                                 GT_OreDictUnificator.get(OrePrefixes.wireGt08, Materials.Aluminium, 2),
                                 GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 4) },
                         Materials.Electrum.getMolten(144),
@@ -437,7 +437,8 @@ public class Assembler implements Runnable {
             {
                 // Dynamo EV 64A
                 GT_Values.RA.addAssemblerRecipe(
-                        new ItemStack[] { CustomItemList.eM_dynamoMulti16_EV.get(1),
+                        new ItemStack[] { getItemContainer("WetTransformer_IV_EV").get(1),
+                                CustomItemList.eM_dynamoMulti16_EV.get(1),
                                 GT_OreDictUnificator.get(OrePrefixes.wireGt12, Materials.Aluminium, 2),
                                 GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 6) },
                         Materials.Tungsten.getMolten(144),
@@ -674,7 +675,7 @@ public class Assembler implements Runnable {
             {
                 // Energy Hatch EV 16A
                 GT_Values.RA.addAssemblerRecipe(
-                        new ItemStack[] { CustomItemList.eM_energyMulti4_EV.get(1),
+                        new ItemStack[] { ItemList.Transformer_IV_EV.get(1), CustomItemList.eM_energyMulti4_EV.get(1),
                                 GT_OreDictUnificator.get(OrePrefixes.wireGt08, Materials.Aluminium, 2),
                                 GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 4) },
                         Materials.Electrum.getMolten(144),
@@ -794,7 +795,8 @@ public class Assembler implements Runnable {
             {
                 // Energy Hatch EV 64A
                 GT_Values.RA.addAssemblerRecipe(
-                        new ItemStack[] { CustomItemList.eM_energyMulti16_EV.get(1),
+                        new ItemStack[] { getItemContainer("WetTransformer_IV_EV").get(1),
+                                CustomItemList.eM_energyMulti16_EV.get(1),
                                 GT_OreDictUnificator.get(OrePrefixes.wireGt12, Materials.Aluminium, 2),
                                 GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 6) },
                         Materials.Tungsten.getMolten(144),


### PR DESCRIPTION
Fixes an oversight in the recipes for the new multiamp EV hatches from https://github.com/GTNewHorizons/TecTech/pull/139. They were missing the transformers.