### PR TITLE
Rework EOH overclock formula

### DIFF
--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_EM_EyeOfHarmony.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_EM_EyeOfHarmony.java
@@ -98,6 +98,7 @@ public class GT_MetaTileEntity_EM_EyeOfHarmony extends GT_MetaTileEntity_Multibl
     private static final double TIME_ACCEL_DECREASE_CHANCE_PER_TIER = 0.1;
     // % Increase in recipe chance and % decrease in yield per tier.
     private static final double STABILITY_INCREASE_PROBABILITY_DECREASE_YIELD_PER_TIER = 0.05;
+    private static final double LOG_BASE_CONSTANT = Math.log(4.4);
 
     private static final int TOTAL_CASING_TIERS_WITH_POWER_PENALTY = 8;
 
@@ -746,7 +747,7 @@ public class GT_MetaTileEntity_EM_EyeOfHarmony extends GT_MetaTileEntity_Multibl
 
     private double hydrogenOverflowProbabilityAdjustment;
     private double heliumOverflowProbabilityAdjustment;
-    private static final long TICKS_BETWEEN_HATCH_DRAIN = EOH_DEBUG_MODE ? 10 : 50;
+    private static final long TICKS_BETWEEN_HATCH_DRAIN = EOH_DEBUG_MODE ? 10 : 20;
 
     private List<ItemStackLong> outputItems = new ArrayList<>();
 
@@ -1138,7 +1139,7 @@ public class GT_MetaTileEntity_EM_EyeOfHarmony extends GT_MetaTileEntity_Multibl
         // Remove EU from the users network.
         if (!addEUToGlobalEnergyMap(
                 userUUID,
-                (long) (-startEU * (Math.log(currentCircuitMultiplier + 1) / Math.log(4.4) + 1)
+                (long) (-startEU * (Math.log(currentCircuitMultiplier + 1) / LOG_BASE_CONSTANT + 1)
                         * pow(0.77, currentCircuitMultiplier)))) {
             return false;
         }
@@ -1363,7 +1364,7 @@ public class GT_MetaTileEntity_EM_EyeOfHarmony extends GT_MetaTileEntity_Multibl
                                 + RESET
                                 + " L");
             }
-            long euPerTick = (long) (startEU * (Math.log(currentCircuitMultiplier + 1) / Math.log(4.4) + 1)
+            long euPerTick = (long) (startEU * (Math.log(currentCircuitMultiplier + 1) / LOG_BASE_CONSTANT + 1)
                     * pow(0.77, currentCircuitMultiplier)
                     - euOutput * (1 - ((TOTAL_CASING_TIERS_WITH_POWER_PENALTY - stabilisationFieldMetadata)
                             * STABILITY_INCREASE_PROBABILITY_DECREASE_YIELD_PER_TIER)))

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_EM_EyeOfHarmony.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_EM_EyeOfHarmony.java
@@ -955,15 +955,14 @@ public class GT_MetaTileEntity_EM_EyeOfHarmony extends GT_MetaTileEntity_Multibl
                         "is avaliable the items/fluids will be " + UNDERLINE + DARK_RED + "voided" + RESET + GRAY + ".")
                 .addInfo(TOOLTIP_BAR)
                 .addInfo("This multiblock can be overclocked by placing a programmed circuit into the input bus.")
+                .addInfo("Each OC halves recipe time and increases startup cost by a factor of:")
+                .addInfo(GREEN + "(log4.4(overclockAmount + 1) + 1) * 0.77^overclockAmount")
                 .addInfo(
-                        "Each OC halves recipe time and increases startup cost by a factor of " + GREEN
-                                + "log4.4(overclockAmount + 1) + 1"
-                                + RESET
+                        "Furthermore, each OC decreases the power output by a factor of " + RED
+                                + "0.77^overclockAmount"
                                 + GRAY
                                 + ".")
-                .addInfo(
-                        "E.g. A circuit of 2 will provide 2 OCs, 1.74x EU consumed and 0.25x the time. All outputs are equal.")
-                .addInfo(TOOLTIP_BAR)
+                .addInfo("All item and fluid output chances & amounts per recipe are unaffected.").addInfo(TOOLTIP_BAR)
                 .addInfo(
                         "If a recipe fails the EOH will output " + GREEN
                                 + "successChance * "
@@ -1139,7 +1138,8 @@ public class GT_MetaTileEntity_EM_EyeOfHarmony extends GT_MetaTileEntity_Multibl
         // Remove EU from the users network.
         if (!addEUToGlobalEnergyMap(
                 userUUID,
-                (long) (-startEU * (Math.log(currentCircuitMultiplier + 1) / Math.log(4.4) + 1)))) {
+                (long) (-startEU * (Math.log(currentCircuitMultiplier + 1) / Math.log(4.4) + 1)
+                        * pow(0.77, currentCircuitMultiplier)))) {
             return false;
         }
 
@@ -1159,7 +1159,7 @@ public class GT_MetaTileEntity_EM_EyeOfHarmony extends GT_MetaTileEntity_Multibl
         successChance = recipeChanceCalculator();
 
         // Determine EU recipe output.
-        euOutput = recipeObject.getEUOutput();
+        euOutput = (long) (recipeObject.getEUOutput() * pow(0.77, currentCircuitMultiplier));
 
         // Reduce internal storage by hydrogen and helium quantity required for recipe.
         validFluidMap.put(Materials.Hydrogen.getGas(1), 0L);
@@ -1364,6 +1364,7 @@ public class GT_MetaTileEntity_EM_EyeOfHarmony extends GT_MetaTileEntity_Multibl
                                 + " L");
             }
             long euPerTick = (long) (startEU * (Math.log(currentCircuitMultiplier + 1) / Math.log(4.4) + 1)
+                    * pow(0.77, currentCircuitMultiplier)
                     - euOutput * (1 - ((TOTAL_CASING_TIERS_WITH_POWER_PENALTY - stabilisationFieldMetadata)
                             * STABILITY_INCREASE_PROBABILITY_DECREASE_YIELD_PER_TIER)))
                     / -maxProgresstime();

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_EM_EyeOfHarmony.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_EM_EyeOfHarmony.java
@@ -955,7 +955,7 @@ public class GT_MetaTileEntity_EM_EyeOfHarmony extends GT_MetaTileEntity_Multibl
                         "is avaliable the items/fluids will be " + UNDERLINE + DARK_RED + "voided" + RESET + GRAY + ".")
                 .addInfo(TOOLTIP_BAR)
                 .addInfo("This multiblock can be overclocked by placing a programmed circuit into the input bus.")
-                .addInfo("Each OC halves recipe time and increases startup cost by a factor of:")
+                .addInfo("Each OC halves recipe time and multiplies startup cost by a factor of:")
                 .addInfo(GREEN + "(log4.4(overclockAmount + 1) + 1) * 0.77^overclockAmount")
                 .addInfo(
                         "Furthermore, each OC decreases the power output by a factor of " + RED

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_EM_EyeOfHarmony.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_EM_EyeOfHarmony.java
@@ -956,7 +956,13 @@ public class GT_MetaTileEntity_EM_EyeOfHarmony extends GT_MetaTileEntity_Multibl
                 .addInfo(TOOLTIP_BAR)
                 .addInfo("This multiblock can be overclocked by placing a programmed circuit into the input bus.")
                 .addInfo(
-                        "E.g. A circuit of 2 will provide 2 OCs, 16x EU consumed and 0.25x the time. All outputs are equal.")
+                        "Each OC halves recipe time and increases startup cost by " + GREEN
+                                + "log4.4(overclockAmount + 1) + 1"
+                                + RESET
+                                + GRAY
+                                + ".")
+                .addInfo(
+                        "E.g. A circuit of 2 will provide 2 OCs, 1.74x EU consumed and 0.25x the time. All outputs are equal.")
                 .addInfo(TOOLTIP_BAR)
                 .addInfo(
                         "If a recipe fails the EOH will output " + GREEN
@@ -1131,7 +1137,9 @@ public class GT_MetaTileEntity_EM_EyeOfHarmony extends GT_MetaTileEntity_Multibl
         startEU = recipeObject.getEUStartCost();
 
         // Remove EU from the users network.
-        if (!addEUToGlobalEnergyMap(userUUID, (long) (-startEU * pow(4, currentCircuitMultiplier)))) {
+        if (!addEUToGlobalEnergyMap(
+                userUUID,
+                (long) (-startEU * (Math.log(currentCircuitMultiplier + 1) / Math.log(4.4) + 1)))) {
             return false;
         }
 
@@ -1355,10 +1363,10 @@ public class GT_MetaTileEntity_EM_EyeOfHarmony extends GT_MetaTileEntity_Multibl
                                 + RESET
                                 + " L");
             }
-            long euPerTick = (long) -(startEU * pow(4, currentCircuitMultiplier)
+            long euPerTick = (long) (startEU * (Math.log(currentCircuitMultiplier + 1) / Math.log(4.4) + 1)
                     - euOutput * (1 - ((TOTAL_CASING_TIERS_WITH_POWER_PENALTY - stabilisationFieldMetadata)
                             * STABILITY_INCREASE_PROBABILITY_DECREASE_YIELD_PER_TIER)))
-                    / maxProgresstime();
+                    / -maxProgresstime();
             if (abs(euPerTick) < LongMath.pow(10, 12)) {
                 str.add("Estimated EU/t: " + RED + formatNumbers(euPerTick) + RESET + " EU/t");
             } else {

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_EM_EyeOfHarmony.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_EM_EyeOfHarmony.java
@@ -956,7 +956,7 @@ public class GT_MetaTileEntity_EM_EyeOfHarmony extends GT_MetaTileEntity_Multibl
                 .addInfo(TOOLTIP_BAR)
                 .addInfo("This multiblock can be overclocked by placing a programmed circuit into the input bus.")
                 .addInfo(
-                        "Each OC halves recipe time and increases startup cost by " + GREEN
+                        "Each OC halves recipe time and increases startup cost by a factor of " + GREEN
                                 + "log4.4(overclockAmount + 1) + 1"
                                 + RESET
                                 + GRAY


### PR DESCRIPTION
Redo of the EOH overclock formula to make overclocks more reasonable power cost wise. 
The old formula increases the power cost by a ludicrous amount, making overclocks completely unusable at higher EOH tiers. 
This new formula aims to fix that issue and make overclocks viable.

Comparison of the two formulas can be found here
https://www.desmos.com/calculator/46gizo08do