### PR TITLE
butcher EOH controller recipe time to 5m like every other controller were

### DIFF
--- a/src/main/java/com/github/technus/tectech/loader/recipe/ResearchStationAssemblyLine.java
+++ b/src/main/java/com/github/technus/tectech/loader/recipe/ResearchStationAssemblyLine.java
@@ -2572,7 +2572,7 @@ public class ResearchStationAssemblyLine implements Runnable {
                             FluidUtils.getFluidStack("molten.metastable oganesson", 144 * 256 * 4),
                             FluidUtils.getFluidStack("molten.shirabon", 144 * 256 * 4), },
                     CustomItemList.Machine_Multi_EyeOfHarmony.get(1),
-                    1_000_000,
+                    5 * MINUTES,
                     (int) TierEU.RECIPE_UMV);
         }
 


### PR DESCRIPTION
Butcher EOH recipe time down to 5 minutes like it always should.
Waiting for multiblock controller shouldn't be job time-investment like, especially when the controller is THAT expensive to begin with