### PR TITLE
Fix EOH recipe time

### DIFF
--- a/src/main/java/com/github/technus/tectech/loader/recipe/ResearchStationAssemblyLine.java
+++ b/src/main/java/com/github/technus/tectech/loader/recipe/ResearchStationAssemblyLine.java
@@ -2572,7 +2572,7 @@ public class ResearchStationAssemblyLine implements Runnable {
                             FluidUtils.getFluidStack("molten.metastable oganesson", 144 * 256 * 4),
                             FluidUtils.getFluidStack("molten.shirabon", 144 * 256 * 4), },
                     CustomItemList.Machine_Multi_EyeOfHarmony.get(1),
-                    5 * MINUTES,
+                    400 * MINUTES,
                     (int) TierEU.RECIPE_UMV);
         }
 


### PR DESCRIPTION
This recipe was "buffed" by ~170x by someone to a nonsense number. The user at this tier is making likely in the region of 500B EU/t, if not more. OCing this 5-6 times will cost 236B - 1T EU/t and take 375-750 seconds. A much more reasonable value.

For comparison, this multi at its best makes 12T EU/t, that means that the EU cost to craft this currently is 6% of 1 tick of energy output. This is clearly absurd.

In future please discuss content changes with the actual author to get intent rather than randomly changing things.