### PR TITLE
Fix energy infuser and stocking bus interaction

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1684218858
+//version: 1685785062
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -1276,12 +1276,14 @@ tasks.register('faq') {
     description = 'Prints frequently asked questions about building a project'
 
     doLast {
-        print("If your build fails to fetch dependencies, they might have been deleted and replaced by newer " +
-            "versions.\nCheck if the versions you try to fetch are still on the distributing sites.\n" +
-            "The links can be found in repositories.gradle and build.gradle:repositories, " +
-            "not build.gradle:buildscript.repositories - this one is for gradle plugin metadata.\n\n" +
+        print("If your build fails to fetch dependencies, run './gradlew updateDependencies'. " +
+            "Or you can manually check if the versions are still on the distributing sites - " +
+            "the links can be found in repositories.gradle and build.gradle:repositories, " +
+            "but not build.gradle:buildscript.repositories - those ones are for gradle plugin metadata.\n\n" +
             "If your build fails to recognize the syntax of new Java versions, enable Jabel in your " +
-            "gradle.properties. See how it's done in GTNH ExampleMod/gradle.properties.")
+            "gradle.properties. See how it's done in GTNH ExampleMod/gradle.properties. " +
+            "However, keep in mind that Jabel enables only syntax features, but not APIs that were introduced in " +
+            "Java 9 or later.")
     }
 }
 

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_EM_infuser.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_EM_infuser.java
@@ -30,6 +30,7 @@ import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_InputBus;
 import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
+import gregtech.common.tileentities.machines.GT_MetaTileEntity_Hatch_InputBus_ME;
 import ic2.api.item.ElectricItem;
 import ic2.api.item.IElectricItem;
 
@@ -45,9 +46,8 @@ public class GT_MetaTileEntity_EM_infuser extends GT_MetaTileEntity_MultiblockBa
     // region structure
     private static final String[] description = new String[] {
             EnumChatFormatting.AQUA + translateToLocal("tt.keyphrase.Hint_Details") + ":",
-            translateToLocal("gt.blockmachines.multimachine.em.infuser.hint"), // 1 - Classic Hatches or High Power
-                                                                               // Casing
-    };
+            // 1 - Classic Hatches or High Power Casing
+            translateToLocal("gt.blockmachines.multimachine.em.infuser.hint"), };
 
     private static final IStructureDefinition<GT_MetaTileEntity_EM_infuser> STRUCTURE_DEFINITION = IStructureDefinition
             .<GT_MetaTileEntity_EM_infuser>builder()
@@ -154,22 +154,20 @@ public class GT_MetaTileEntity_EM_infuser extends GT_MetaTileEntity_MultiblockBa
     @Override
     public boolean checkRecipe_EM(ItemStack itemStack) {
         for (GT_MetaTileEntity_Hatch_InputBus inputBus : mInputBusses) {
-            if (inputBus.mInventory != null) {
-                for (ItemStack itemStackInBus : inputBus.mInventory) {
-                    if (itemStackInBus != null) {
-                        Item item = itemStackInBus.getItem();
-                        if (itemStackInBus.stackSize == 1 && item != null) {
-                            if (isItemStackFullyCharged(itemStackInBus) && isItemStackFullyRepaired(itemStackInBus)) {
-                                if (addOutput(itemStackInBus)) {
-                                    this.depleteInput(itemStackInBus);
-                                }
-                            } else {
-                                mEfficiencyIncrease = 10000;
-                                mMaxProgresstime = 20;
-                                return true;
-                            }
-                        }
+            if (inputBus instanceof GT_MetaTileEntity_Hatch_InputBus_ME) continue;
+            for (int i = 0; i < inputBus.getSizeInventory(); i++) {
+                ItemStack itemStackInBus = inputBus.getStackInSlot(i);
+                if (itemStackInBus == null) continue;
+                Item item = itemStackInBus.getItem();
+                if (itemStackInBus.stackSize != 1 || item == null) continue;
+                if (isItemStackFullyCharged(itemStackInBus) && isItemStackFullyRepaired(itemStackInBus)) {
+                    if (addOutput(itemStackInBus)) {
+                        this.depleteInput(itemStackInBus);
                     }
+                } else {
+                    mEfficiencyIncrease = 10000;
+                    mMaxProgresstime = 20;
+                    return true;
                 }
             }
         }
@@ -181,45 +179,41 @@ public class GT_MetaTileEntity_EM_infuser extends GT_MetaTileEntity_MultiblockBa
         boolean itemProcessed = false;
         startRecipeProcessing();
         for (GT_MetaTileEntity_Hatch_InputBus inputBus : mInputBusses) {
-            if (inputBus.mInventory != null) {
-                for (ItemStack itemStackInBus : inputBus.mInventory) {
-                    if (itemStackInBus != null) {
-                        Item item = itemStackInBus.getItem();
-                        if (itemStackInBus.stackSize == 1 && item != null) {
-                            if (isItemStackFullyCharged(itemStackInBus) && isItemStackFullyRepaired(itemStackInBus)) {
-                                itemProcessed = true;
-                                if (addOutput(itemStackInBus)) {
-                                    this.depleteInput(itemStackInBus);
-                                }
-                            } else {
-                                if (item.isRepairable()) {
-                                    FluidStack uum = getStoredFluids().stream()
-                                            .filter(fluid -> Materials.UUMatter.getFluid(1).isFluidEqual(fluid))
-                                            .findAny().orElse(null);
-                                    if (uum != null) {
-                                        int repairedDamage = Math
-                                                .min(item.getDamage(itemStackInBus), maxRepairedDamagePerOperation);
-                                        long euCost = repairedDamage * usedEuPerDurability;
-                                        if (getEUVar() >= euCost && depleteInput(
-                                                new FluidStack(
-                                                        Materials.UUMatter.mFluid,
-                                                        repairedDamage * usedUumPerDurability))) {
-                                            item.setDamage(
-                                                    itemStackInBus,
-                                                    Math.max(item.getDamage(itemStackInBus) - repairedDamage, 0));
-                                            setEUVar(Math.min(getEUVar() - euCost, 0));
-                                        }
-                                    }
-                                }
-                                if (item instanceof IElectricItem) {
-                                    doChargeItemStack((IElectricItem) item, itemStackInBus);
-                                    return;
-                                } else if (TecTech.hasCOFH && item instanceof IEnergyContainerItem) {
-                                    doChargeItemStackRF((IEnergyContainerItem) item, itemStackInBus);
-                                    return;
-                                }
+            if (inputBus instanceof GT_MetaTileEntity_Hatch_InputBus_ME) continue;
+            for (int i = 0; i < inputBus.getSizeInventory(); i++) {
+                ItemStack itemStackInBus = inputBus.getStackInSlot(i);
+                if (itemStackInBus == null) continue;
+                Item item = itemStackInBus.getItem();
+                if (itemStackInBus.stackSize != 1 || item == null) continue;
+                if (isItemStackFullyCharged(itemStackInBus) && isItemStackFullyRepaired(itemStackInBus)) {
+                    itemProcessed = true;
+                    if (addOutput(itemStackInBus)) {
+                        this.depleteInput(itemStackInBus);
+                    }
+                } else {
+                    if (item.isRepairable()) {
+                        FluidStack uum = getStoredFluids().stream()
+                                .filter(fluid -> Materials.UUMatter.getFluid(1).isFluidEqual(fluid)).findAny()
+                                .orElse(null);
+                        if (uum != null) {
+                            int repairedDamage = Math
+                                    .min(item.getDamage(itemStackInBus), maxRepairedDamagePerOperation);
+                            long euCost = repairedDamage * usedEuPerDurability;
+                            if (getEUVar() >= euCost && depleteInput(
+                                    new FluidStack(Materials.UUMatter.mFluid, repairedDamage * usedUumPerDurability))) {
+                                item.setDamage(
+                                        itemStackInBus,
+                                        Math.max(item.getDamage(itemStackInBus) - repairedDamage, 0));
+                                setEUVar(Math.min(getEUVar() - euCost, 0));
                             }
                         }
+                    }
+                    if (item instanceof IElectricItem) {
+                        doChargeItemStack((IElectricItem) item, itemStackInBus);
+                        return;
+                    } else if (TecTech.hasCOFH && item instanceof IEnergyContainerItem) {
+                        doChargeItemStackRF((IEnergyContainerItem) item, itemStackInBus);
+                        return;
                     }
                 }
             }
@@ -233,39 +227,39 @@ public class GT_MetaTileEntity_EM_infuser extends GT_MetaTileEntity_MultiblockBa
     @Override
     public GT_Multiblock_Tooltip_Builder createTooltip() {
         final GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
-        tt.addMachineType(translateToLocal("gt.blockmachines.multimachine.em.infuser.name")) // Machine Type: Energy
-                                                                                             // Infuser
-                .addInfo(translateToLocal("gt.blockmachines.multimachine.em.infuser.desc.0")) // Controller block of the
-                                                                                              // Energy Infuser
-                .addInfo(translateToLocal("gt.blockmachines.multimachine.em.infuser.desc.1")) // Can be used to charge
-                                                                                              // items (lossless)
-                .addInfo(translateToLocal("gt.blockmachines.multimachine.em.infuser.desc.2")) // Can be fed with
-                                                                                              // UU-Matter to repair
-                                                                                              // items
-                .addSeparator().beginStructureBlock(3, 5, 3, false)
-                .addController(translateToLocal("tt.keyword.Structure.FrontCenter3rd")) // Controller: Front 3rd layer
-                                                                                        // center
-                .addOtherStructurePart(
+        // Machine Type: Energy Infuser
+        tt.addMachineType(translateToLocal("gt.blockmachines.multimachine.em.infuser.name"))
+                // Controller block of the Energy Infuser
+                .addInfo(translateToLocal("gt.blockmachines.multimachine.em.infuser.desc.0"))
+                // Can be used to charge items (lossless)
+                .addInfo(translateToLocal("gt.blockmachines.multimachine.em.infuser.desc.1"))
+                // Can be fed with UU-Matter to repair items
+                .addInfo(translateToLocal("gt.blockmachines.multimachine.em.infuser.desc.2"))
+                // Stocking Bus is not supported
+                .addInfo(translateToLocal("gt.blockmachines.multimachine.em.infuser.desc.3")).addSeparator()
+                .beginStructureBlock(3, 5, 3, false)
+                // Controller: Front 3rd layer center
+                .addController(translateToLocal("tt.keyword.Structure.FrontCenter3rd")).addOtherStructurePart(
+                        // High Power
                         translateToLocal("gt.blockcasingsTT.0.name"),
-                        translateToLocal("gt.blockmachines.multimachine.em.infuser.Structure.HighPowerCasing")) // High
-                                                                                                                // Power
+                        translateToLocal("gt.blockmachines.multimachine.em.infuser.Structure.HighPowerCasing"))
                 // Casing: Layer
                 // 1 and 5
                 .addOtherStructurePart(
+                        // Molecular Coil
                         translateToLocal("gt.blockcasingsTT.7.name"),
-                        translateToLocal("gt.blockmachines.multimachine.em.infuser.Structure.MolecularCoil")) // Molecular
-                                                                                                              // Coil:
+                        translateToLocal("gt.blockmachines.multimachine.em.infuser.Structure.MolecularCoil"))
                 // Layer 2 and 4
                 .addOtherStructurePart(
+                        // Molecular
                         translateToLocal("gt.blockcasingsTT.4.name"),
-                        translateToLocal("gt.blockmachines.multimachine.em.infuser.Structure.MolecularCasing")) // Molecular
+                        translateToLocal("gt.blockmachines.multimachine.em.infuser.Structure.MolecularCasing"))
                 // Casing: Layer
                 // 3 (hollow)
-                .addEnergyHatch(translateToLocal("tt.keyword.Structure.AnyHighPowerCasing"), 1) // Energy Hatch: Any
-                                                                                                // High Power Casing
-                .addMaintenanceHatch(translateToLocal("tt.keyword.Structure.AnyHighPowerCasing"), 1) // Maintenance
-                                                                                                     // Hatch: Any High
-                                                                                                     // Power Casing
+                // Energy Hatch: Any High Power Casing
+                .addEnergyHatch(translateToLocal("tt.keyword.Structure.AnyHighPowerCasing"), 1)
+                // Maintenance Hatch: Any High Power Casing
+                .addMaintenanceHatch(translateToLocal("tt.keyword.Structure.AnyHighPowerCasing"), 1)
                 .toolTipFinisher(CommonValues.TEC_MARK_GENERAL);
         return tt;
     }

--- a/src/main/resources/assets/tectech/lang/en_US.lang
+++ b/src/main/resources/assets/tectech/lang/en_US.lang
@@ -755,6 +755,7 @@ gt.blockmachines.multimachine.em.infuser.hint=1 - Classic Hatches or High Power 
 gt.blockmachines.multimachine.em.infuser.desc.0=Controller block of the Energy Infuser
 gt.blockmachines.multimachine.em.infuser.desc.1=Can be used to charge items (lossless)
 gt.blockmachines.multimachine.em.infuser.desc.2=Can be fed with UU-Matter to repair items
+gt.blockmachines.multimachine.em.infuser.desc.3=Stocking Bus is not supported
 gt.blockmachines.multimachine.em.infuser.Structure.HighPowerCasing=Layer 1 and 5
 gt.blockmachines.multimachine.em.infuser.Structure.MolecularCoil=Layer 2 and 4
 gt.blockmachines.multimachine.em.infuser.Structure.MolecularCasing=Layer 3


### PR DESCRIPTION
Close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13749
Simply using `getStackInSlot` instead of direct access to `mInventory` fixes the issue, but we still don't have way to change NBT of items in the ME network. Since it's very niche usage, I just excluded support for stocking bus.