### PR TITLE
Eoh controller recipe time changed to be longer than t9 casing time

### DIFF
--- a/src/main/java/com/github/technus/tectech/loader/recipe/ResearchStationAssemblyLine.java
+++ b/src/main/java/com/github/technus/tectech/loader/recipe/ResearchStationAssemblyLine.java
@@ -2572,7 +2572,7 @@ public class ResearchStationAssemblyLine implements Runnable {
                             FluidUtils.getFluidStack("molten.metastable oganesson", 144 * 256 * 4),
                             FluidUtils.getFluidStack("molten.shirabon", 144 * 256 * 4), },
                     CustomItemList.Machine_Multi_EyeOfHarmony.get(1),
-                    400 * MINUTES,
+                    1600 * MINUTES,
                     (int) TierEU.RECIPE_UMV);
         }
 

--- a/src/main/java/com/github/technus/tectech/loader/recipe/ResearchStationAssemblyLine.java
+++ b/src/main/java/com/github/technus/tectech/loader/recipe/ResearchStationAssemblyLine.java
@@ -2572,7 +2572,7 @@ public class ResearchStationAssemblyLine implements Runnable {
                             FluidUtils.getFluidStack("molten.metastable oganesson", 144 * 256 * 4),
                             FluidUtils.getFluidStack("molten.shirabon", 144 * 256 * 4), },
                     CustomItemList.Machine_Multi_EyeOfHarmony.get(1),
-                    1600 * MINUTES,
+                    26*HOURS+40*MINUTES,
                     (int) TierEU.RECIPE_UMV);
         }
 


### PR DESCRIPTION
It does not make sense for the controller to have a shorter recipe time than its casings. Eoh craft time was never an issue for crafting both gates.