### PR TITLE
Fixing power checks from telsa tower

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 gtnh.settings.blowdryerTag = 0.2.0
 
 # Human-readable mod name, available for mcmod.info population.
-modName = TecTech - Tec Technology!
+modName = TecTech - Tec Technology\!
 
 # Case-sensitive identifier string, available for mcmod.info population and used for automatic mixin JSON generation.
 # Conventionally lowercase.
@@ -33,7 +33,7 @@ channel = stable
 mappingsVersion = 12
 
 # Defines other MCP mappings for dependency deobfuscation.
-remoteMappings = https://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
+remoteMappings = https\://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
 
 # Select a default username for testing your mod. You can always override this per-run by running
 # `./gradlew runClient --username=AnotherPlayer`, or configuring this command in your IDE.
@@ -60,6 +60,9 @@ gradleTokenModId =
 
 # [DEPRECATED] Mod name replacement token.
 gradleTokenModName =
+
+# [DEPRECATED] Mod Group replacement token.
+gradleTokenGroupName =
 
 # [DEPRECATED]
 # Multiple source files can be defined here by providing a comma-separated list: Class1.java,Class2.java,Class3.java
@@ -123,7 +126,7 @@ includeWellKnownRepositories = true
 usesMavenPublishing = true
 
 # Maven repository to publish the mod to.
-# mavenPublishUrl = https://nexus.gtnewhorizons.com/repository/releases/
+# mavenPublishUrl = https\://nexus.gtnewhorizons.com/repository/releases/
 
 # Publishing to Modrinth requires you to set the MODRINTH_TOKEN environment variable to your current Modrinth API token.
 #
@@ -187,5 +190,3 @@ customArchiveBaseName = TecTech
 # This is meant to be set in $HOME/.gradle/gradle.properties.
 # ideaCheckSpotlessOnBuild = true
 
-# Non-GTNH properties
-gradleTokenGroupName = 

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.9'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.14'
 }
 
 

--- a/src/main/java/com/github/technus/tectech/thing/cover/GT_Cover_TM_TeslaCoil.java
+++ b/src/main/java/com/github/technus/tectech/thing/cover/GT_Cover_TM_TeslaCoil.java
@@ -52,8 +52,8 @@ public class GT_Cover_TM_TeslaCoil extends GT_CoverBehavior {
 
     @Override
     public int getTickRate(ForgeDirection side, int aCoverID, int aCoverVariable, ICoverable aTileEntity) {
-        // It updates once every 200 ticks, so once every 10 seconds
-        return 200;
+        // It updates once every 10 ticks, so once every 0.5 second
+        return 10;
     }
 
     public byte getTeslaReceptionCapability() {


### PR DESCRIPTION
Changed check to 10 ticks from 10 seconds to fix power failing on server starting.

Fixes [#14000](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14000)