### PR TITLE
Numeric widget and localized number formatting.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,7 +2,7 @@
 
 dependencies {
     shadowImplementation('com.github.GTNewHorizons:AVRcore:1.0.1')
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.92:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.95:dev')
     api('com.github.GTNewHorizons:Yamcl:0.6.0:dev')
     implementation('com.github.GTNewHorizons:GTNEIOrePlugin:1.2.0:dev')
 
@@ -18,7 +18,7 @@ dependencies {
     // for testing EOH recipes
     //runtimeOnlyNonPublishable("TGregworks:TGregworks:1.7.10-GTNH-1.0.23:deobf")
     //runtimeOnlyNonPublishable('com.github.GTNewHorizons:TinkersConstruct:1.11.11-GTNH:dev')
-    //runtimeOnlyNonPublishable('com.github.GTNewHorizons:NewHorizonsCoreMod:2.3.36:dev')
+    //runtimeOnlyNonPublishable('com.github.GTNewHorizons:NewHorizonsCoreMod:2.3.38:dev')
     //runtimeOnlyNonPublishable('com.github.GTNewHorizons:GoodGenerator:0.8.12:dev') {
     //    exclude group: "com.github.GTNewHorizons", module: "TecTech"
     //}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,7 +2,7 @@
 
 dependencies {
     shadowImplementation('com.github.GTNewHorizons:AVRcore:1.0.1')
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.88:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.92:dev')
     api('com.github.GTNewHorizons:Yamcl:0.6.0:dev')
     implementation('com.github.GTNewHorizons:GTNEIOrePlugin:1.2.0:dev')
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,14 +2,14 @@
 
 dependencies {
     shadowImplementation('com.github.GTNewHorizons:AVRcore:1.0.1')
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.79:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.88:dev')
     api('com.github.GTNewHorizons:Yamcl:0.6.0:dev')
     implementation('com.github.GTNewHorizons:GTNEIOrePlugin:1.2.0:dev')
 
     compileOnly("TGregworks:TGregworks:1.7.10-GTNH-1.0.23:deobf") {transitive=false}
     compileOnly('com.github.GTNewHorizons:TinkersConstruct:1.11.11-GTNH:dev') {transitive=false}
-    compileOnly('com.github.GTNewHorizons:OpenComputers:1.10.6-GTNH:dev') {transitive=false}
-    compileOnly('com.github.GTNewHorizons:GTplusplus:1.11.31:dev') {transitive=false}
+    compileOnly('com.github.GTNewHorizons:OpenComputers:1.10.7-GTNH:dev') {transitive=false}
+    compileOnly('com.github.GTNewHorizons:GTplusplus:1.11.33:dev') {transitive=false}
     compileOnly('com.github.GTNewHorizons:Avaritia:1.49:dev') {transitive=false}
 
     compileOnly('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev') {transitive=false}
@@ -18,7 +18,7 @@ dependencies {
     // for testing EOH recipes
     //runtimeOnlyNonPublishable("TGregworks:TGregworks:1.7.10-GTNH-1.0.23:deobf")
     //runtimeOnlyNonPublishable('com.github.GTNewHorizons:TinkersConstruct:1.11.11-GTNH:dev')
-    //runtimeOnlyNonPublishable('com.github.GTNewHorizons:NewHorizonsCoreMod:2.3.31:dev')
+    //runtimeOnlyNonPublishable('com.github.GTNewHorizons:NewHorizonsCoreMod:2.3.36:dev')
     //runtimeOnlyNonPublishable('com.github.GTNewHorizons:GoodGenerator:0.8.12:dev') {
     //    exclude group: "com.github.GTNewHorizons", module: "TecTech"
     //}

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.14'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.16'
 }
 
 

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/hatch/GT_MetaTileEntity_Hatch_Uncertainty.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/hatch/GT_MetaTileEntity_Hatch_Uncertainty.java
@@ -392,7 +392,7 @@ public class GT_MetaTileEntity_Hatch_Uncertainty extends GT_MetaTileEntity_Hatch
                 .widget(new FakeSyncWidget.ByteSyncer(() -> status, val -> status = val));
 
         builder.widget(
-                TextWidget.dynamicString(() -> "Status: " + (status == 0 ? "OK" : "NG")).setSynced(false)
+                new TextWidget().setStringSupplier(() -> "Status: " + (status == 0 ? "OK" : "NG"))
                         .setDefaultColor(COLOR_TEXT_WHITE.get()).setPos(46, 7));
 
         for (int i = 0; i < 9; i++) {

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/base/GT_MetaTileEntity_MultiblockBase_EM.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/base/GT_MetaTileEntity_MultiblockBase_EM.java
@@ -48,7 +48,6 @@ import com.github.technus.tectech.thing.metaTileEntity.hatch.GT_MetaTileEntity_H
 import com.github.technus.tectech.thing.metaTileEntity.hatch.GT_MetaTileEntity_Hatch_Param;
 import com.github.technus.tectech.thing.metaTileEntity.hatch.GT_MetaTileEntity_Hatch_Uncertainty;
 import com.github.technus.tectech.thing.metaTileEntity.multi.base.render.TT_RenderedExtendedFacingTexture;
-import com.github.technus.tectech.util.TT_Utility;
 import com.google.common.collect.Iterables;
 import com.gtnewhorizon.structurelib.StructureLibAPI;
 import com.gtnewhorizon.structurelib.alignment.IAlignment;
@@ -56,6 +55,7 @@ import com.gtnewhorizon.structurelib.alignment.IAlignmentProvider;
 import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
 import com.gtnewhorizon.structurelib.structure.IStructureElement;
 import com.gtnewhorizon.structurelib.util.Vec3Impl;
+import com.gtnewhorizons.modularui.api.NumberFormatMUI;
 import com.gtnewhorizons.modularui.api.drawable.IDrawable;
 import com.gtnewhorizons.modularui.api.drawable.UITexture;
 import com.gtnewhorizons.modularui.api.math.Alignment;
@@ -205,6 +205,13 @@ public abstract class GT_MetaTileEntity_MultiblockBase_EM
     /** Flag if the new long power variable should be used */
     protected boolean useLongPower = false;
 
+    // Locale-aware formatting of numbers.
+    protected static NumberFormatMUI numberFormat;
+    static {
+        numberFormat = new NumberFormatMUI();
+        numberFormat.setMaximumFractionDigits(8);
+    }
+
     // endregion
 
     protected GT_MetaTileEntity_MultiblockBase_EM(int aID, String aName, String aNameRegional) {
@@ -342,7 +349,7 @@ public abstract class GT_MetaTileEntity_MultiblockBase_EM
         list.add(
                 EnumChatFormatting.WHITE + "Value: "
                         + EnumChatFormatting.AQUA
-                        + TT_Utility.doubleToString(parametrization.getIn(hatchNo, paramID)));
+                        + numberFormat.format(parametrization.getIn(hatchNo, paramID)));
         try {
             list.add(parametrization.groups[hatchNo].parameterIn[paramID].getBrief());
         } catch (NullPointerException | IndexOutOfBoundsException e) {
@@ -369,7 +376,7 @@ public abstract class GT_MetaTileEntity_MultiblockBase_EM
         list.add(
                 EnumChatFormatting.WHITE + "Value: "
                         + EnumChatFormatting.AQUA
-                        + TT_Utility.doubleToString(parametrization.getOut(hatchNo, paramID)));
+                        + numberFormat.format(parametrization.getOut(hatchNo, paramID)));
         try {
             list.add(parametrization.groups[hatchNo].parameterOut[paramID].getBrief());
         } catch (NullPointerException | IndexOutOfBoundsException e) {

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/base/GT_MetaTileEntity_MultiblockBase_EM.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/base/GT_MetaTileEntity_MultiblockBase_EM.java
@@ -71,7 +71,7 @@ import com.gtnewhorizons.modularui.common.widget.DynamicPositionedColumn;
 import com.gtnewhorizons.modularui.common.widget.FakeSyncWidget;
 import com.gtnewhorizons.modularui.common.widget.SlotWidget;
 import com.gtnewhorizons.modularui.common.widget.TextWidget;
-import com.gtnewhorizons.modularui.common.widget.textfield.TextFieldWidget;
+import com.gtnewhorizons.modularui.common.widget.textfield.NumericWidget;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -2564,15 +2564,11 @@ public abstract class GT_MetaTileEntity_MultiblockBase_EM
                                 (screenSize.height / 2 - mainWindow.getSize().height / 2)))
                 .widget(ButtonWidget.closeWindowButton(true).setPos(85, 3))
                 .widget(
-                        new TextFieldWidget().setTextColor(Color.LIGHT_BLUE.normal).setNumbersDouble((val) -> val)
-                                .setGetter(() -> Double.toString(parametrization.iParamsIn[ledID])).setSetter(val -> {
-                                    try {
-                                        parametrization.iParamsIn[ledID] = Double.parseDouble(val);
-                                    } catch (Exception e) {
-                                        e.printStackTrace();
-                                    }
-                                }).setTextAlignment(Alignment.CenterLeft).setFocusOnGuiOpen(true)
-                                .setMaximumFractionDigits(8).setBackground(GT_UITextures.BACKGROUND_TEXT_FIELD)
+                        new NumericWidget().setGetter(() -> parametrization.iParamsIn[ledID])
+                                .setSetter(val -> parametrization.iParamsIn[ledID] = val).setIntegerOnly(false)
+                                .modifyNumberFormat(format -> format.setMaximumFractionDigits(8))
+                                .setTextColor(Color.LIGHT_BLUE.normal).setTextAlignment(Alignment.CenterLeft)
+                                .setFocusOnGuiOpen(true).setBackground(GT_UITextures.BACKGROUND_TEXT_FIELD)
                                 .setPos(5, 20).setSize(90, 15))
                 .widget(
                         new TextWidget((ledID % 10) + ":" + (ledID / 10) + ":I").setDefaultColor(Color.WHITE.normal)

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/single/GT_MetaTileEntity_BuckConverter.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/single/GT_MetaTileEntity_BuckConverter.java
@@ -17,6 +17,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import com.github.technus.tectech.util.CommonValues;
 import com.github.technus.tectech.util.TT_Utility;
+import com.gtnewhorizons.modularui.api.NumberFormatMUI;
 import com.gtnewhorizons.modularui.api.drawable.IDrawable;
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
 import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
@@ -42,6 +43,7 @@ public class GT_MetaTileEntity_BuckConverter extends GT_MetaTileEntity_TieredMac
 
     private static GT_RenderedTexture BUCK, BUCK_ACTIVE;
     public int EUT = 0, AMP = 0;
+    private static NumberFormatMUI numberFormat = new NumberFormatMUI();
 
     public GT_MetaTileEntity_BuckConverter(int aID, String aName, String aNameRegional, int aTier) {
         super(
@@ -217,16 +219,16 @@ public class GT_MetaTileEntity_BuckConverter extends GT_MetaTileEntity_TieredMac
         builder.widget(
                 new DrawableWidget().setDrawable(GT_UITextures.PICTURE_SCREEN_BLACK).setSize(90, 72).setPos(43, 4))
                 .widget(
-                        TextWidget.dynamicString(() -> "EUT: " + EUT).setDefaultColor(COLOR_TEXT_WHITE.get())
-                                .setPos(46, 8))
+                        new TextWidget().setStringSupplier(() -> "EUT: " + numberFormat.format(EUT))
+                                .setDefaultColor(COLOR_TEXT_WHITE.get()).setPos(46, 8))
                 .widget(
-                        TextWidget.dynamicString(() -> "TIER: " + VN[TT_Utility.getTier(Math.abs(EUT))])
+                        new TextWidget().setStringSupplier(() -> "TIER: " + VN[TT_Utility.getTier(Math.abs(EUT))])
                                 .setDefaultColor(COLOR_TEXT_WHITE.get()).setPos(46, 16))
                 .widget(
-                        TextWidget.dynamicString(() -> "AMP: " + AMP).setDefaultColor(COLOR_TEXT_WHITE.get())
-                                .setPos(46, 24))
+                        new TextWidget().setStringSupplier(() -> "AMP: " + numberFormat.format(AMP))
+                                .setDefaultColor(COLOR_TEXT_WHITE.get()).setPos(46, 24))
                 .widget(
-                        TextWidget.dynamicString(() -> "SUM: " + (long) AMP * EUT)
+                        new TextWidget().setStringSupplier(() -> "SUM: " + numberFormat.format((long) AMP * EUT))
                                 .setDefaultColor(COLOR_TEXT_WHITE.get()).setPos(46, 32));
 
         addChangeNumberButton(builder, GT_UITextures.OVERLAY_BUTTON_MINUS_LARGE, val -> EUT -= val, 512, 64, 7, 4);

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/single/GT_MetaTileEntity_DebugPollutor.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/single/GT_MetaTileEntity_DebugPollutor.java
@@ -16,6 +16,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 import com.github.technus.tectech.TecTech;
 import com.github.technus.tectech.util.CommonValues;
 import com.github.technus.tectech.util.TT_Utility;
+import com.gtnewhorizons.modularui.api.NumberFormatMUI;
 import com.gtnewhorizons.modularui.api.drawable.IDrawable;
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
 import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
@@ -45,6 +46,7 @@ public class GT_MetaTileEntity_DebugPollutor extends GT_MetaTileEntity_TieredMac
 
     private static GT_RenderedTexture POLLUTOR;
     public int pollution = 0;
+    private static final NumberFormatMUI numberFormat = new NumberFormatMUI();
 
     public GT_MetaTileEntity_DebugPollutor(int aID, String aName, String aNameRegional, int aTier) {
         super(
@@ -170,7 +172,7 @@ public class GT_MetaTileEntity_DebugPollutor extends GT_MetaTileEntity_TieredMac
         builder.widget(
                 new DrawableWidget().setDrawable(GT_UITextures.PICTURE_SCREEN_BLACK).setSize(90, 72).setPos(43, 4))
                 .widget(
-                        TextWidget.dynamicString(() -> "Pollution: " + pollution)
+                        new TextWidget().setStringSupplier(() -> "Pollution: " + numberFormat.format(pollution))
                                 .setDefaultColor(COLOR_TEXT_WHITE.get()).setPos(46, 8));
 
         addChangeNumberButton(

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/single/GT_MetaTileEntity_DebugPowerGenerator.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/single/GT_MetaTileEntity_DebugPowerGenerator.java
@@ -10,7 +10,8 @@ import static com.github.technus.tectech.util.CommonValues.VN;
 import static net.minecraft.util.StatCollector.translateToLocal;
 
 import java.util.function.Consumer;
-import java.util.function.Supplier;
+import java.util.function.IntConsumer;
+import java.util.function.IntSupplier;
 
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayer;
@@ -31,7 +32,7 @@ import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
 import com.gtnewhorizons.modularui.common.widget.ButtonWidget;
 import com.gtnewhorizons.modularui.common.widget.DrawableWidget;
 import com.gtnewhorizons.modularui.common.widget.TextWidget;
-import com.gtnewhorizons.modularui.common.widget.textfield.TextFieldWidget;
+import com.gtnewhorizons.modularui.common.widget.textfield.NumericWidget;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -357,11 +358,10 @@ public class GT_MetaTileEntity_DebugPowerGenerator extends GT_MetaTileEntity_Tie
     }
 
     private void addLabelledIntegerTextField(ModularWindow.Builder builder, String label, int labelWidth,
-            Supplier<Integer> getter, Consumer<Integer> setter, int xPos, int yPos) {
-        TextFieldWidget itfw = new TextFieldWidget();
-        TextWidget ltw = new TextWidget(label);
-        builder.widget(ltw.setDefaultColor(COLOR_TEXT_WHITE.get()).setPos(xPos, yPos)).widget(
-                itfw.setSetterInt(setter).setGetterInt(getter).setTextColor(COLOR_TEXT_WHITE.get())
+            IntSupplier getter, IntConsumer setter, int xPos, int yPos) {
+        builder.widget(new TextWidget(label).setDefaultColor(COLOR_TEXT_WHITE.get()).setPos(xPos, yPos)).widget(
+                new NumericWidget().setGetter(() -> (double) getter.getAsInt())
+                        .setSetter(val -> setter.accept((int) val)).setTextColor(COLOR_TEXT_WHITE.get())
                         .setBackground(GT_UITextures.BACKGROUND_TEXT_FIELD.withOffset(-1, -1, 2, 2))
                         .setPos(xPos + labelWidth, yPos - 1).setSize(56, 10));
     }

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/single/GT_MetaTileEntity_DebugPowerGenerator.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/single/GT_MetaTileEntity_DebugPowerGenerator.java
@@ -26,6 +26,7 @@ import com.github.technus.tectech.thing.metaTileEntity.hatch.GT_MetaTileEntity_H
 import com.github.technus.tectech.thing.metaTileEntity.pipe.GT_MetaTileEntity_Pipe_Energy;
 import com.github.technus.tectech.util.CommonValues;
 import com.github.technus.tectech.util.TT_Utility;
+import com.gtnewhorizons.modularui.api.NumberFormatMUI;
 import com.gtnewhorizons.modularui.api.drawable.IDrawable;
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
 import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
@@ -59,6 +60,7 @@ public class GT_MetaTileEntity_DebugPowerGenerator extends GT_MetaTileEntity_Tie
     private boolean LASER = false;
     public int EUT = 0, AMP = 0;
     public boolean producing = true;
+    private static final NumberFormatMUI numberFormat = new NumberFormatMUI();
 
     public GT_MetaTileEntity_DebugPowerGenerator(int aID, String aName, String aNameRegional, int aTier) {
         super(
@@ -326,11 +328,11 @@ public class GT_MetaTileEntity_DebugPowerGenerator extends GT_MetaTileEntity_Tie
                 new DrawableWidget().setDrawable(GT_UITextures.PICTURE_SCREEN_BLACK).setSize(90, 72).setPos(43, 4))
 
                 .widget(
-                        TextWidget.dynamicString(() -> "TIER: " + VN[TT_Utility.getTier(Math.abs(EUT))])
+                        new TextWidget().setStringSupplier(() -> "TIER: " + VN[TT_Utility.getTier(Math.abs(EUT))])
                                 .setDefaultColor(COLOR_TEXT_WHITE.get()).setPos(46, 22))
 
                 .widget(
-                        TextWidget.dynamicString(() -> "SUM: " + (long) AMP * EUT)
+                        new TextWidget().setStringSupplier(() -> "SUM: " + numberFormat.format((long) AMP * EUT))
                                 .setDefaultColor(COLOR_TEXT_WHITE.get()).setPos(46, 46));
 
         addLabelledIntegerTextField(builder, "EUT: ", 24, this::getEUT, this::setEUT, 46, 8);
@@ -360,8 +362,8 @@ public class GT_MetaTileEntity_DebugPowerGenerator extends GT_MetaTileEntity_Tie
     private void addLabelledIntegerTextField(ModularWindow.Builder builder, String label, int labelWidth,
             IntSupplier getter, IntConsumer setter, int xPos, int yPos) {
         builder.widget(new TextWidget(label).setDefaultColor(COLOR_TEXT_WHITE.get()).setPos(xPos, yPos)).widget(
-                new NumericWidget().setGetter(() -> (double) getter.getAsInt())
-                        .setSetter(val -> setter.accept((int) val)).setTextColor(COLOR_TEXT_WHITE.get())
+                new NumericWidget().setGetter(getter::getAsInt).setSetter(val -> setter.accept((int) val))
+                        .setTextColor(COLOR_TEXT_WHITE.get())
                         .setBackground(GT_UITextures.BACKGROUND_TEXT_FIELD.withOffset(-1, -1, 2, 2))
                         .setPos(xPos + labelWidth, yPos - 1).setSize(56, 10));
     }

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/single/GT_MetaTileEntity_DebugStructureWriter.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/single/GT_MetaTileEntity_DebugStructureWriter.java
@@ -224,19 +224,19 @@ public class GT_MetaTileEntity_DebugStructureWriter extends GT_MetaTileEntity_Ti
         builder.widget(
                 new DrawableWidget().setDrawable(GT_UITextures.PICTURE_SCREEN_BLACK).setSize(90, 72).setPos(43, 4))
                 .widget(
-                        TextWidget.dynamicString(() -> size ? "Structure size" : "My position")
+                        new TextWidget().setStringSupplier(() -> size ? "Structure size" : "My position")
                                 .setDefaultColor(COLOR_TEXT_WHITE.get()).setPos(46, 8))
                 .widget(
-                        TextWidget.dynamicString(() -> size ? "(Changing scan size)" : "(Moving origin)")
+                        new TextWidget().setStringSupplier(() -> size ? "(Changing scan size)" : "(Moving origin)")
                                 .setDefaultColor(COLOR_TEXT_WHITE.get()).setPos(46, 16))
                 .widget(
-                        TextWidget.dynamicString(() -> "A: " + numbers[size ? 3 : 0])
+                        new TextWidget().setStringSupplier(() -> "A: " + numbers[size ? 3 : 0])
                                 .setDefaultColor(COLOR_TEXT_WHITE.get()).setPos(46, 24))
                 .widget(
-                        TextWidget.dynamicString(() -> "B: " + numbers[size ? 4 : 1])
+                        new TextWidget().setStringSupplier(() -> "B: " + numbers[size ? 4 : 1])
                                 .setDefaultColor(COLOR_TEXT_WHITE.get()).setPos(46, 32))
                 .widget(
-                        TextWidget.dynamicString(() -> "C: " + numbers[size ? 5 : 2])
+                        new TextWidget().setStringSupplier(() -> "C: " + numbers[size ? 5 : 2])
                                 .setDefaultColor(COLOR_TEXT_WHITE.get()).setPos(46, 40));
 
         addChangeNumberButtons(builder, GT_UITextures.OVERLAY_BUTTON_MINUS_LARGE, -512, -64, 7);

--- a/src/main/java/com/github/technus/tectech/util/TT_Utility.java
+++ b/src/main/java/com/github/technus/tectech/util/TT_Utility.java
@@ -168,12 +168,4 @@ public final class TT_Utility {
         }
         return previousValue;
     }
-
-    public static String doubleToString(double value) {
-        if (value == (long) value) {
-            return Long.toString((long) value);
-        }
-        return Double.toString(value);
-    }
-
 }


### PR DESCRIPTION
* Replaces text fields where the user is expected to input a number with NumericWidget, supporting extended syntax and formatting. (See https://github.com/GTNewHorizons/ModularUI/pull/62.)
* Replaces instances where a dynamic text field is being communicated between server and client with a purely client-side method. In some cases this allows the client to do localization on these texts correctly. (See https://github.com/GTNewHorizons/ModularUI/pull/69.)
* Modifies other instances where the UI displays a number to use a locale-aware formatter. (See https://github.com/GTNewHorizons/ModularUI/pull/67.)

&nbsp;

Notes:
* I have not touched Parametrizer Hatches, they are deprecated and uncraftable, even though they contain some code that should have been changed if they were still intended to be used. This will not break any setups that still use them; although their UI will not have the new features.
* Some labels currently display as gray, when they are intended to be a different color. This is already fixed in https://github.com/GTNewHorizons/ModularUI/pull/70, and will be automatically corrected once new releases of MUI and GT5 are published.
* Tracking down every single instance where a mod writes a number is nearly impossible. I use a few heuristics and code searches, but it is very likely that I miss some places. If an UI displays an unformatted or wrongly formatted number somewhere, please report it to be fixed.

Preview:
![](https://i.imgur.com/1Umr68g.gif)

This is the first real field implementation of the localization and UI changes I've been working on for a while. I chose to start with TT simply because it has fewest places where the changes are applicable. I will continue working through all other mods that use ModularUI.