### PR TITLE
Fix memory leak by tesla, but problem still exists when using tesla cover.

### DIFF
--- a/src/main/java/com/github/technus/tectech/thing/cover/GT_Cover_TM_TeslaCoil.java
+++ b/src/main/java/com/github/technus/tectech/thing/cover/GT_Cover_TM_TeslaCoil.java
@@ -1,6 +1,7 @@
 package com.github.technus.tectech.thing.cover;
 
 import static com.github.technus.tectech.mechanics.tesla.ITeslaConnectable.TeslaUtil.teslaSimpleNodeSetAdd;
+import static com.github.technus.tectech.mechanics.tesla.ITeslaConnectable.TeslaUtil.teslaSimpleNodeSetRemove;
 import static ic2.api.info.Info.DMG_ELECTRIC;
 
 import net.minecraft.entity.player.EntityPlayer;
@@ -16,18 +17,27 @@ public class GT_Cover_TM_TeslaCoil extends GT_CoverBehavior {
 
     public GT_Cover_TM_TeslaCoil() {}
 
+    private  TeslaCoverConnection mConnection;
+
     @Override
     public int doCoverThings(ForgeDirection side, byte aInputRedstone, int aCoverID, int aCoverVariable,
             ICoverable aTileEntity, long aTimer) {
         // Only do stuff if we're on top and have power
+        if(mConnection == null) {
+            mConnection = new TeslaCoverConnection(aTileEntity.getIGregTechTileEntityOffset(0, 0, 0),
+                    getTeslaReceptionCapability());
+        }
         if (side == ForgeDirection.UP || aTileEntity.getEUCapacity() > 0) {
             // Makes sure we're on the list
-            teslaSimpleNodeSetAdd(
-                    new TeslaCoverConnection(
-                            aTileEntity.getIGregTechTileEntityOffset(0, 0, 0),
-                            getTeslaReceptionCapability()));
+            teslaSimpleNodeSetAdd(mConnection);
         }
         return super.doCoverThings(side, aInputRedstone, aCoverID, aCoverVariable, aTileEntity, aTimer);
+    }
+
+    @Override
+    public boolean onCoverRemoval(ForgeDirection side, int aCoverID, int aCoverVariable, ICoverable aTileEntity, boolean aForced) {
+        teslaSimpleNodeSetRemove(mConnection);
+        return super.onCoverRemoval(side, aCoverID, aCoverVariable, aTileEntity, aForced);
     }
 
     @Override

--- a/src/main/java/com/github/technus/tectech/thing/cover/GT_Cover_TM_TeslaCoil.java
+++ b/src/main/java/com/github/technus/tectech/thing/cover/GT_Cover_TM_TeslaCoil.java
@@ -17,26 +17,27 @@ public class GT_Cover_TM_TeslaCoil extends GT_CoverBehavior {
 
     public GT_Cover_TM_TeslaCoil() {}
 
-    private  TeslaCoverConnection mConnection;
-
     @Override
     public int doCoverThings(ForgeDirection side, byte aInputRedstone, int aCoverID, int aCoverVariable,
             ICoverable aTileEntity, long aTimer) {
         // Only do stuff if we're on top and have power
-        if(mConnection == null) {
-            mConnection = new TeslaCoverConnection(aTileEntity.getIGregTechTileEntityOffset(0, 0, 0),
-                    getTeslaReceptionCapability());
-        }
         if (side == ForgeDirection.UP || aTileEntity.getEUCapacity() > 0) {
             // Makes sure we're on the list
-            teslaSimpleNodeSetAdd(mConnection);
+            teslaSimpleNodeSetAdd(
+                    new TeslaCoverConnection(
+                            aTileEntity.getIGregTechTileEntityOffset(0, 0, 0),
+                            getTeslaReceptionCapability()));
         }
         return super.doCoverThings(side, aInputRedstone, aCoverID, aCoverVariable, aTileEntity, aTimer);
     }
 
     @Override
-    public boolean onCoverRemoval(ForgeDirection side, int aCoverID, int aCoverVariable, ICoverable aTileEntity, boolean aForced) {
-        teslaSimpleNodeSetRemove(mConnection);
+    public boolean onCoverRemoval(ForgeDirection side, int aCoverID, int aCoverVariable, ICoverable aTileEntity,
+            boolean aForced) {
+        teslaSimpleNodeSetRemove(
+                new TeslaCoverConnection(
+                        aTileEntity.getIGregTechTileEntityOffset(0, 0, 0),
+                        getTeslaReceptionCapability()));
         return super.onCoverRemoval(side, aCoverID, aCoverVariable, aTileEntity, aForced);
     }
 

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_TM_teslaCoil.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_TM_teslaCoil.java
@@ -709,6 +709,13 @@ public class GT_MetaTileEntity_TM_teslaCoil extends GT_MetaTileEntity_Multiblock
     }
 
     @Override
+    public void onUnload() {
+        if(!getBaseMetaTileEntity().isClientSide()) {
+            teslaSimpleNodeSetRemove(this);
+        }
+    }
+
+    @Override
     protected void parametersInstantiation_EM() {
         Parameters.Group hatch_0 = parametrization.getGroup(0, true);
         Parameters.Group hatch_1 = parametrization.getGroup(1, true);

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_TM_teslaCoil.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_TM_teslaCoil.java
@@ -710,7 +710,7 @@ public class GT_MetaTileEntity_TM_teslaCoil extends GT_MetaTileEntity_Multiblock
 
     @Override
     public void onUnload() {
-        if(!getBaseMetaTileEntity().isClientSide()) {
+        if (!getBaseMetaTileEntity().isClientSide()) {
             teslaSimpleNodeSetRemove(this);
         }
     }

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/single/GT_MetaTileEntity_TeslaCoil.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/single/GT_MetaTileEntity_TeslaCoil.java
@@ -239,7 +239,7 @@ public class GT_MetaTileEntity_TeslaCoil extends GT_MetaTileEntity_BasicBatteryB
 
     @Override
     public void onUnload() {
-        if(!this.getBaseMetaTileEntity().isClientSide()) {
+        if (!this.getBaseMetaTileEntity().isClientSide()) {
             teslaSimpleNodeSetRemove(this);
         }
     }

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/single/GT_MetaTileEntity_TeslaCoil.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/single/GT_MetaTileEntity_TeslaCoil.java
@@ -238,6 +238,13 @@ public class GT_MetaTileEntity_TeslaCoil extends GT_MetaTileEntity_BasicBatteryB
     }
 
     @Override
+    public void onUnload() {
+        if(!this.getBaseMetaTileEntity().isClientSide()) {
+            teslaSimpleNodeSetRemove(this);
+        }
+    }
+
+    @Override
     public void loadNBTData(NBTTagCompound aNBT) {
         super.loadNBTData(aNBT);
         teslaSimpleNodeSetAdd(this);


### PR DESCRIPTION
As this issue [*](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14727) said, the tesla leaks memory and will finally increase mspt and crash the server.

Tesla controller block didn't implement onUnload() method, so when chunk unloads, it will leak a controller TE object.
Tesla cover didn't implement onCoverRemoval() method, so when it's removed from hatches, a TeslaCoverConnection object leaks.

And I suggest removal of tesla cover, or do completely rework on tesla, because there's no callback for covers when the chunk unloads or the hatch it attaches get removed. So there's no chance for developer to remove the TeslaCoverConnection object from set to release the memory.

 You shouldn't do any side effects in cover logic, unless you make sure you can handle it.