### PR TITLE
Show amperes in/out in tooltip of energy hatches.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,14 +2,14 @@
 
 dependencies {
     shadowImplementation('com.github.GTNewHorizons:AVRcore:1.0.1')
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.124:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.130:dev')
     api('com.github.GTNewHorizons:Yamcl:0.6.0:dev')
     implementation('com.github.GTNewHorizons:GTNEIOrePlugin:1.2.0:dev')
 
     compileOnly("TGregworks:TGregworks:1.7.10-GTNH-1.0.23:deobf") {transitive=false}
-    compileOnly('com.github.GTNewHorizons:TinkersConstruct:1.11.12-GTNH:dev') {transitive=false}
-    compileOnly('com.github.GTNewHorizons:OpenComputers:1.10.7-GTNH:dev') {transitive=false}
-    compileOnly('com.github.GTNewHorizons:GTplusplus:1.11.48:dev') {transitive=false}
+    compileOnly('com.github.GTNewHorizons:TinkersConstruct:1.11.13-GTNH:dev') {transitive=false}
+    compileOnly('com.github.GTNewHorizons:OpenComputers:1.10.8-GTNH:dev') {transitive=false}
+    compileOnly('com.github.GTNewHorizons:GTplusplus:1.11.49:dev') {transitive=false}
     compileOnly('com.github.GTNewHorizons:Avaritia:1.49:dev') {transitive=false}
 
     compileOnly('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev') {transitive=false}
@@ -17,7 +17,7 @@ dependencies {
 
     // for testing EOH recipes
     //runtimeOnlyNonPublishable("TGregworks:TGregworks:1.7.10-GTNH-1.0.23:deobf")
-    //runtimeOnlyNonPublishable('com.github.GTNewHorizons:TinkersConstruct:1.11.12-GTNH:dev')
+    //runtimeOnlyNonPublishable('com.github.GTNewHorizons:TinkersConstruct:1.11.13-GTNH:dev')
     //runtimeOnlyNonPublishable('com.github.GTNewHorizons:NewHorizonsCoreMod:2.3.42:dev')
     //runtimeOnlyNonPublishable('com.github.GTNewHorizons:GoodGenerator:0.8.18:dev') {
     //    exclude group: "com.github.GTNewHorizons", module: "TecTech"

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/hatch/GT_MetaTileEntity_Hatch_EnergyMulti.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/hatch/GT_MetaTileEntity_Hatch_EnergyMulti.java
@@ -3,10 +3,10 @@ package com.github.technus.tectech.thing.metaTileEntity.hatch;
 import static com.github.technus.tectech.thing.metaTileEntity.Textures.OVERLAYS_ENERGY_IN_POWER_TT;
 import static com.github.technus.tectech.util.CommonValues.V;
 import static net.minecraft.util.StatCollector.translateToLocal;
+import static net.minecraft.util.StatCollector.translateToLocalFormatted;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.EnumChatFormatting;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import com.github.technus.tectech.util.CommonValues;
@@ -16,7 +16,6 @@ import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch;
-import gregtech.api.util.GT_Utility;
 
 /**
  * Created by danie_000 on 16.12.2016.
@@ -34,10 +33,8 @@ public class GT_MetaTileEntity_Hatch_EnergyMulti extends GT_MetaTileEntity_Hatch
                 0,
                 new String[] { CommonValues.TEC_MARK_GENERAL,
                         translateToLocal("gt.blockmachines.hatch.energymulti.desc.0"),
-                        translateToLocal("gt.blockmachines.hatch.energymulti.desc.1") + ": "
-                                + EnumChatFormatting.AQUA
-                                + GT_Utility.formatNumbers(aAmp)
-                                + " A" }); // Multiple Ampere Energy Injector for Multiblocks
+                        translateToLocalFormatted("gt.blockmachines.hatch.energymulti.desc.2", aAmp + (aAmp >> 2)),
+                        translateToLocalFormatted("gt.blockmachines.hatch.energymulti.desc.3", aAmp) });
         Amperes = aAmp;
         TT_Utility.setTier(aTier, this);
     }

--- a/src/main/resources/assets/tectech/lang/en_US.lang
+++ b/src/main/resources/assets/tectech/lang/en_US.lang
@@ -228,6 +228,8 @@ gt.blockmachines.hatch.energymulti16.tier.13.name=UXV 16A Energy Hatch
 gt.blockmachines.hatch.energymulti64.tier.13.name=UXV 64A Energy Hatch
 gt.blockmachines.hatch.energymulti.desc.0=Multiple Ampere Energy Injector for Multiblocks
 gt.blockmachines.hatch.energymulti.desc.1=Amperes In
+gt.blockmachines.hatch.energymulti.desc.2=Accepts up to %d Amps from energy network
+gt.blockmachines.hatch.energymulti.desc.3=Provides up to %d Amps to the multiblock
 
 achievement.gt.blockmachines.hatch.energywirelessmulti04.tier.04=EV 4A Wireless Energy Hatch
 achievement.gt.blockmachines.hatch.energywirelessmulti16.tier.04=EV 16A Wireless Energy Hatch


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15842.

![](https://i.imgur.com/IPp6UqD.png)

&nbsp;

Note: Can somebody please test this? In my dev environment the new tooltip does not show until I delete and regenerate `GregTech.lang`. I'm not sure if this is something to do with me, or if TT is not updating this file correctly.

Edit: should be fixed by https://github.com/GTNewHorizons/GT5-Unofficial/pull/2552.