### PR TITLE
Fix conflicting recipes for EOH dilation parts.

### DIFF
--- a/src/main/java/com/github/technus/tectech/loader/recipe/ResearchStationAssemblyLine.java
+++ b/src/main/java/com/github/technus/tectech/loader/recipe/ResearchStationAssemblyLine.java
@@ -2857,6 +2857,16 @@ public class ResearchStationAssemblyLine implements Runnable {
                     CustomItemList.TimeAccelerationFieldGeneratorTier7.get(1),
                     CustomItemList.TimeAccelerationFieldGeneratorTier8.get(1) };
 
+            // Spectral Components
+            // Cycling should fix issues with conflicting recipes for T1-T2, T4-T5 & T7-T8
+            final ItemStack[] spectralComponents = new ItemStack[] {
+                    // Red Spectral Component
+                    getModItem(SuperSolarPanels.ID, "redcomponent", 64),
+                    // Green Spectral Component
+                    getModItem(SuperSolarPanels.ID, "greencomponent", 64),
+                    // Blue Spectral Component
+                    getModItem(SuperSolarPanels.ID, "bluecomponent", 64) };
+
             for (int absoluteTier = 0; absoluteTier < 9; absoluteTier++) {
 
                 TT_recipeAdder.addResearchableAssemblylineRecipe(
@@ -2871,11 +2881,11 @@ public class ResearchStationAssemblyLine implements Runnable {
 
                                 getItemContainer("QuantumCircuit").get(absoluteTier + 1),
                                 // Red Spectral Component
-                                getModItem(SuperSolarPanels.ID, "redcomponent", 64),
+                                spectralComponents[absoluteTier % spectralComponents.length],
                                 // Green Spectral Component
-                                getModItem(SuperSolarPanels.ID, "greencomponent", 64),
+                                spectralComponents[(absoluteTier + 1) % spectralComponents.length],
                                 // Blue Spectral Component
-                                getModItem(SuperSolarPanels.ID, "bluecomponent", 64),
+                                spectralComponents[(absoluteTier + 2) % spectralComponents.length],
 
                                 plateList[absoluteTier],
                                 // Dyson Swarm Module Deployment Unit Base Casing


### PR DESCRIPTION
This pr addresses some recipe conflicts that can happen between different EOH dilation casings.
- T1-T2 all use white dwarf matter and mk2 fusions
![image](https://github.com/GTNewHorizons/TecTech/assets/17766417/0bf8844c-56ee-4943-b3b7-5db2b969ed55)
![image](https://github.com/GTNewHorizons/TecTech/assets/17766417/bbc0b78a-0b53-443e-bb7c-64fb11f047e9)
- T4-T5 all use black dwarf matter and mk3 fusions
![image](https://github.com/GTNewHorizons/TecTech/assets/17766417/3b051c5e-dd1f-46fd-9591-c6da58fe3b47)
![image](https://github.com/GTNewHorizons/TecTech/assets/17766417/8046f4ca-739a-4854-b96d-be493d3ccf08)
- T8-T9 all use MHDCSM and mk4 fusions
![image](https://github.com/GTNewHorizons/TecTech/assets/17766417/1c7f5c18-0bce-4c4d-8376-44150d8e40bc)
![image](https://github.com/GTNewHorizons/TecTech/assets/17766417/3d2fb244-2f61-4d33-9352-4abe69d88c38)
