### PR TITLE
Add scanner mode for research station

### DIFF
--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_EM_EyeOfHarmony.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_EM_EyeOfHarmony.java
@@ -37,6 +37,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.annotation.Nonnull;
+
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -83,6 +85,7 @@ import gregtech.api.recipe.check.CheckRecipeResultRegistry;
 import gregtech.api.recipe.check.SimpleCheckRecipeResult;
 import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
 import gregtech.api.util.GT_Utility;
+import gregtech.api.util.shutdown.ShutDownReason;
 import gregtech.common.tileentities.machines.GT_MetaTileEntity_Hatch_InputBus_ME;
 import gregtech.common.tileentities.machines.GT_MetaTileEntity_Hatch_OutputBus_ME;
 import gregtech.common.tileentities.machines.GT_MetaTileEntity_Hatch_Output_ME;
@@ -1381,8 +1384,8 @@ public class GT_MetaTileEntity_EM_EyeOfHarmony extends GT_MetaTileEntity_Multibl
     }
 
     @Override
-    public void stopMachine() {
-        super.stopMachine();
+    public void stopMachine(@Nonnull ShutDownReason reason) {
+        super.stopMachine(reason);
         destroyRenderBlock();
         recipeRunning = false;
     }

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_EM_computer.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_EM_computer.java
@@ -21,6 +21,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import javax.annotation.Nonnull;
+
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
@@ -61,6 +63,7 @@ import gregtech.api.recipe.check.CheckRecipeResultRegistry;
 import gregtech.api.recipe.check.SimpleCheckRecipeResult;
 import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
 import gregtech.api.util.IGT_HatchAdder;
+import gregtech.api.util.shutdown.ShutDownReason;
 
 /**
  * Created by danie_000 on 17.12.2016.
@@ -417,8 +420,8 @@ public class GT_MetaTileEntity_EM_computer extends GT_MetaTileEntity_MultiblockB
     }
 
     @Override
-    public void stopMachine() {
-        super.stopMachine();
+    public void stopMachine(@Nonnull ShutDownReason reason) {
+        super.stopMachine(reason);
         eAvailableData = 0;
         for (GT_MetaTileEntity_Hatch_Rack rack : filterValidMTEs(eRacks)) {
             rack.getBaseMetaTileEntity().setActive(false);

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_EM_research.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_EM_research.java
@@ -9,6 +9,7 @@ import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlock;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.transpose;
 import static gregtech.api.enums.GT_HatchElement.Energy;
 import static gregtech.api.enums.GT_HatchElement.Maintenance;
+import static gregtech.api.recipe.RecipeMaps.scannerFakeRecipes;
 import static gregtech.api.util.GT_StructureUtility.buildHatchAdder;
 import static gregtech.api.util.GT_Utility.filterValidMTEs;
 import static mcp.mobius.waila.api.SpecialChars.GREEN;
@@ -31,6 +32,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.nbt.NBTTagString;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -60,6 +62,7 @@ import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_Energ
 import gregtech.api.recipe.check.CheckRecipeResult;
 import gregtech.api.recipe.check.CheckRecipeResultRegistry;
 import gregtech.api.recipe.check.SimpleCheckRecipeResult;
+import gregtech.api.util.GT_AssemblyLineUtils;
 import gregtech.api.util.GT_LanguageManager;
 import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
 import gregtech.api.util.GT_Recipe;
@@ -81,8 +84,9 @@ public class GT_MetaTileEntity_EM_research extends GT_MetaTileEntity_MultiblockB
     // region variables
     private final ArrayList<GT_MetaTileEntity_Hatch_Holder> eHolders = new ArrayList<>();
     private GT_Recipe.GT_Recipe_AssemblyLine tRecipe;
-    private String machineType;
     private static final String assembly = "Assembly line";
+    private static final String scanner = "Scanner";
+    private String machineType = assembly;
     private ItemStack holdItem;
     private long computationRemaining, computationRequired;
 
@@ -353,12 +357,44 @@ public class GT_MetaTileEntity_EM_research extends GT_MetaTileEntity_MultiblockB
         if (!eHolders.isEmpty() && eHolders.get(0).mInventory[0] != null) {
             holdItem = eHolders.get(0).mInventory[0].copy();
             if (ItemList.Tool_DataStick.isStackEqual(controllerStack, false, true)) {
-                for (GT_Recipe.GT_Recipe_AssemblyLine assRecipe : TecTechRecipeMaps.researchableALRecipeList) {
-                    if (GT_Utility.areStacksEqual(assRecipe.mResearchItem, holdItem, true)) {
-                        machineType = assembly;
-                        tRecipe = assRecipe;
-                        // if found
-                        if (iterateRecipes()) return SimpleCheckRecipeResult.ofSuccess("researching");
+                switch (machineType) {
+                    case scanner -> {
+                        for (GT_Recipe.GT_Recipe_AssemblyLine assRecipe : GT_Recipe.GT_Recipe_AssemblyLine.sAssemblylineRecipes) {
+                            if (GT_Utility.areStacksEqual(assRecipe.mResearchItem, holdItem, true)) {
+                                boolean failScanner = true;
+                                for (GT_Recipe scannerRecipe : scannerFakeRecipes.getAllRecipes()) {
+                                    if (GT_Utility.areStacksEqual(scannerRecipe.mInputs[0], holdItem, true)) {
+                                        failScanner = false;
+                                        break;
+                                    }
+                                }
+                                if (failScanner) {
+                                    return SimpleCheckRecipeResult.ofFailure("wrongRequirements");
+                                }
+                                this.tRecipe = assRecipe;
+                                // Scanner mode should consume item first
+                                eHolders.get(0).mInventory[0] = null;
+                                mInventory[1] = null;
+                                // Set property
+                                computationRequired = computationRemaining = assRecipe.mResearchTime;
+                                mMaxProgresstime = 20;
+                                mEfficiencyIncrease = 10000;
+                                eRequiredData = 1;
+                                eAmpereFlow = 1;
+                                mEUt = -524288;
+                                eHolders.get(0).getBaseMetaTileEntity().setActive(true);
+                                return SimpleCheckRecipeResult.ofSuccess("scanning");
+                            }
+                        }
+                    }
+                    case assembly -> {
+                        for (GT_Recipe.GT_Recipe_AssemblyLine assRecipe : TecTechRecipeMaps.researchableALRecipeList) {
+                            if (GT_Utility.areStacksEqual(assRecipe.mResearchItem, holdItem, true)) {
+                                tRecipe = assRecipe;
+                                // if found
+                                if (iterateRecipes()) return SimpleCheckRecipeResult.ofSuccess("researching");
+                            }
+                        }
                     }
                 }
             } else {
@@ -376,17 +412,26 @@ public class GT_MetaTileEntity_EM_research extends GT_MetaTileEntity_MultiblockB
     @Override
     public void outputAfterRecipe_EM() {
         if (!eHolders.isEmpty()) {
-            if (tRecipe != null && ItemList.Tool_DataStick.isStackEqual(mInventory[1], false, true)) {
-                eHolders.get(0).getBaseMetaTileEntity().setActive(false);
-                eHolders.get(0).mInventory[0] = null;
-                if (lServerNames == null) {
-                    makeStick();
-                } else {
-                    try {
-                        makeStick2();
-                    } catch (NoSuchFieldError e) {
-                        makeStick();
+            switch (machineType) {
+                case assembly -> {
+                    if (tRecipe != null && ItemList.Tool_DataStick.isStackEqual(mInventory[1], false, true)) {
+                        eHolders.get(0).getBaseMetaTileEntity().setActive(false);
+                        eHolders.get(0).mInventory[0] = null;
+                        if (lServerNames == null) {
+                            makeStick();
+                        } else {
+                            try {
+                                makeStick2();
+                            } catch (NoSuchFieldError e) {
+                                makeStick();
+                            }
+                        }
                     }
+                }
+                case scanner -> {
+                    mInventory[1] = ItemList.Tool_DataStick.get(1);
+                    GT_AssemblyLineUtils.setAssemblyLineRecipeOnDataStick(mInventory[1], tRecipe);
+                    eHolders.get(0).getBaseMetaTileEntity().setActive(false);
                 }
             }
         }
@@ -554,6 +599,7 @@ public class GT_MetaTileEntity_EM_research extends GT_MetaTileEntity_MultiblockB
         super.saveNBTData(aNBT);
         aNBT.setLong("eComputationRemaining", computationRemaining);
         aNBT.setLong("eComputationRequired", computationRequired);
+        aNBT.setString("eMachineType", machineType);
         if (holdItem != null) {
             aNBT.setTag("eHold", holdItem.writeToNBT(new NBTTagCompound()));
         } else {
@@ -566,6 +612,7 @@ public class GT_MetaTileEntity_EM_research extends GT_MetaTileEntity_MultiblockB
         super.loadNBTData(aNBT);
         computationRemaining = aNBT.getLong("eComputationRemaining");
         computationRequired = aNBT.getLong("eComputationRequired");
+        machineType = aNBT.hasKey("eMachineType") ? aNBT.getString("eMachineType") : assembly;
         if (aNBT.hasKey("eHold")) {
             holdItem = ItemStack.loadItemStackFromNBT(aNBT.getCompoundTag("eHold"));
         } else {
@@ -594,7 +641,6 @@ public class GT_MetaTileEntity_EM_research extends GT_MetaTileEntity_MultiblockB
                         for (GT_Recipe.GT_Recipe_AssemblyLine tRecipe : TecTechRecipeMaps.researchableALRecipeList) {
                             if (GT_Utility.areStacksEqual(tRecipe.mResearchItem, holdItem, true)) {
                                 this.tRecipe = tRecipe;
-                                machineType = assembly;
                                 break;
                             }
                         }
@@ -659,11 +705,24 @@ public class GT_MetaTileEntity_EM_research extends GT_MetaTileEntity_MultiblockB
     }
 
     @Override
+    public final void onScrewdriverRightClick(ForgeDirection side, EntityPlayer aPlayer, float aX, float aY, float aZ) {
+        super.onScrewdriverRightClick(side, aPlayer, aX, aY, aZ);
+        switch (machineType) {
+            case scanner -> machineType = assembly;
+            case assembly -> machineType = scanner;
+        }
+        aPlayer.addChatComponentMessage(
+                new ChatComponentTranslation(
+                        "gt.blockmachines.multimachine.em.research.mode." + machineType.replace(" ", "_")));
+    }
+
+    @Override
     public void getWailaNBTData(EntityPlayerMP player, TileEntity tile, NBTTagCompound tag, World world, int x, int y,
             int z) {
         tag.setBoolean("hasProblems", (getIdealStatus() - getRepairStatus()) > 0);
         tag.setFloat("efficiency", mEfficiency / 100.0F);
         tag.setBoolean("incompleteStructure", (getBaseMetaTileEntity().getErrorDisplayID() & 64) != 0);
+        tag.setString("machineType", machineType);
         tag.setLong("computation", (computationRequired - computationRemaining) / 20L);
         tag.setLong("computationRequired", computationRequired / 20L);
     }
@@ -681,7 +740,7 @@ public class GT_MetaTileEntity_EM_research extends GT_MetaTileEntity_MultiblockB
                         + "  Efficiency: "
                         + tag.getFloat("efficiency")
                         + "%");
-
+        currentTip.add("Mode: " + tag.getString("machineType"));
         currentTip.add(
                 String.format(
                         "Computation: %,d / %,d",

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_EM_research.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_EM_research.java
@@ -571,8 +571,8 @@ public class GT_MetaTileEntity_EM_research extends GT_MetaTileEntity_MultiblockB
     }
 
     @Override
-    public void stopMachine() {
-        super.stopMachine();
+    public void stopMachine(@Nonnull ShutDownReason reason) {
+        super.stopMachine(reason);
         for (GT_MetaTileEntity_Hatch_Holder r : eHolders) {
             r.getBaseMetaTileEntity().setActive(false);
         }

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_EM_research.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_EM_research.java
@@ -22,6 +22,8 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 
+import javax.annotation.Nonnull;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
@@ -63,6 +65,7 @@ import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
 import gregtech.api.util.GT_Recipe;
 import gregtech.api.util.GT_Utility;
 import gregtech.api.util.IGT_HatchAdder;
+import gregtech.api.util.shutdown.ShutDownReason;
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
 

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_TM_microwave.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_TM_microwave.java
@@ -16,6 +16,8 @@ import static net.minecraft.util.StatCollector.translateToLocal;
 import java.util.ArrayList;
 import java.util.HashSet;
 
+import javax.annotation.Nonnull;
+
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.EntityItem;
@@ -48,6 +50,7 @@ import gregtech.api.recipe.check.SimpleCheckRecipeResult;
 import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
 import gregtech.api.util.GT_Recipe;
 import gregtech.api.util.GT_Utility;
+import gregtech.api.util.shutdown.ShutDownReason;
 
 /**
  * Created by danie_000 on 17.12.2016.
@@ -294,8 +297,8 @@ public class GT_MetaTileEntity_TM_microwave extends GT_MetaTileEntity_Multiblock
     }
 
     @Override
-    public void stopMachine() {
-        super.stopMachine();
+    public void stopMachine(@Nonnull ShutDownReason reason) {
+        super.stopMachine(reason);
         remainingTime.set(timerSetting.get());
         timerValue.set(0);
     }

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_TM_teslaCoil.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_TM_teslaCoil.java
@@ -41,6 +41,8 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import javax.annotation.Nonnull;
+
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Items;
@@ -108,6 +110,7 @@ import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
 import gregtech.api.util.GT_OreDictUnificator;
 import gregtech.api.util.GT_Utility;
 import gregtech.api.util.IGT_HatchAdder;
+import gregtech.api.util.shutdown.ShutDownReason;
 import gregtech.common.blocks.GT_Item_Machines;
 
 public class GT_MetaTileEntity_TM_teslaCoil extends GT_MetaTileEntity_MultiblockBase_EM
@@ -810,8 +813,8 @@ public class GT_MetaTileEntity_TM_teslaCoil extends GT_MetaTileEntity_Multiblock
     }
 
     @Override
-    public void stopMachine() {
-        super.stopMachine();
+    public void stopMachine(@Nonnull ShutDownReason reason) {
+        super.stopMachine(reason);
         for (GT_MetaTileEntity_Hatch_Capacitor cap : eCapacitorHatches) {
             cap.getBaseMetaTileEntity().setActive(false);
         }

--- a/src/main/resources/assets/tectech/lang/en_US.lang
+++ b/src/main/resources/assets/tectech/lang/en_US.lang
@@ -1139,6 +1139,8 @@ GT5U.gui.text.computing=§aComputing
 GT5U.gui.text.providing_data=§aProviding Data
 GT5U.gui.text.routing=§aRouting
 GT5U.gui.text.researching=§aResearching
+GT5U.gui.text.wrongRequirements=§7Incorrect scanning item
+GT5U.gui.text.scanning=§aScanning
 GT5U.gui.text.charging=§aCharging
 GT5U.gui.text.microwaving=§aMicrowaving
 GT5U.gui.text.no_routing=§7Can't route
@@ -1160,6 +1162,7 @@ GT5U.gui.text.invalid_overdrive_setting=§7Invalid overdrive setting
 GT5U.gui.text.insufficient_power_no_val=§7Insufficient power
 GT5U.gui.text.missing_upgrades=§7Missing upgrades
 GT5U.gui.text.waiting_for_inputs=§7Waiting for inputs
+GT5U.gui.text.computation_loss=§4Shut down due to computation loss.
 
 # RecipeMaps
 gt.recipe.eyeofharmony=Eye of Harmony

--- a/src/main/resources/assets/tectech/lang/en_US.lang
+++ b/src/main/resources/assets/tectech/lang/en_US.lang
@@ -761,6 +761,8 @@ gt.blockmachines.multimachine.em.research.desc.0=Controller block of the Researc
 gt.blockmachines.multimachine.em.research.desc.1=Used to scan Data Sticks for Assembling Line Recipes
 gt.blockmachines.multimachine.em.research.desc.2=Needs to be fed with computation to work
 gt.blockmachines.multimachine.em.research.desc.3=Does not consume the item until the Data Stick is written
+gt.blockmachines.multimachine.em.research.mode.Assembly_line=Mode: Research Station
+gt.blockmachines.multimachine.em.research.mode.Scanner=Mode: Scanner
 
 gt.blockmachines.multimachine.em.collider.name=Matter Collider
 gt.blockmachines.multimachine.em.collider.hint.0=1 - Classic Hatches or High Power Casing


### PR DESCRIPTION
Implementation of https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11045
Use screwdriver to change mode between researching & scanning.
![image](https://github.com/GTNewHorizons/TecTech/assets/31100241/87bcbeb2-cdd0-4aea-83ca-c1e1c2d22360)
Key property:
- computation requirement: 1:1 of ResearchTime (second)
- min computation: fixed 1 (no limit)
- EU/t: fixed UV 1A

This PR also applies the latest shutdownReason to all TT machines.